### PR TITLE
updated with live links

### DIFF
--- a/_user_guides/troubleshooting.md
+++ b/_user_guides/troubleshooting.md
@@ -3,4 +3,4 @@ layout: post
 order: 110
 ---
 
-For troubleshooting tips on [baking](baking_images.md), [deploying](deploying.md), [the pipeline expression language](expression_language.md), or [working with jenkins](working_with_jenkins.md), check out the 'Troubleshooting' sections of those guides.
+For troubleshooting tips on [baking](http://docs.armory.io/user-guides/baking-images/), [deploying](http://docs.armory.io/user-guides/deploying/), or [the pipeline expression language](http://docs.armory.io/user-guides/expression-language/), check out the 'Troubleshooting' sections of those guides. 


### PR DESCRIPTION
Also, Working with Jenkins doesn't actually have a troubleshooting
section. We should add one in, then link to it and update this page.