### PR TITLE
overflow and wide screens

### DIFF
--- a/_assets/css/base/_layout.scss
+++ b/_assets/css/base/_layout.scss
@@ -11,14 +11,14 @@
 		left: 0;
 		position: absolute;
 		top: 0;
-		width: 33.33%;
+		width: 20%;
 	}
 }
 
 .Wrapper__inner {
 	display: flex;
 	margin: 0 auto;
-	max-width: 100rem;
+	max-width: 90%;
 	position: relative;
 }
 

--- a/_assets/css/components/_header.scss
+++ b/_assets/css/components/_header.scss
@@ -1,7 +1,7 @@
 .Header {
 	background: $color-blue-light;
-	flex: 1 1 33.33%;
-	padding: 4rem 0 0 3rem;	
+	flex: 1 1 0%;
+	padding: 4rem 0 0 3rem;
 
 	a {
 		color: $color-text-dark;

--- a/_assets/css/components/_highlight.scss
+++ b/_assets/css/components/_highlight.scss
@@ -81,6 +81,7 @@ figure {
 pre {
 	margin: 0;
 	padding: 1.5rem 1.5rem;
+	overflow: auto;
 }
 
 code {


### PR DESCRIPTION
# support for scrolling code blocks
![scrolling](https://cl.ly/2u1a0l2x1S14/Screen%20Recording%202017-07-19%20at%2007.45%20PM.gif)

# support for wide screens:
## before
![before](https://cl.ly/3x2E0T3l1t25/Screen%20Shot%202017-07-19%20at%207.46.54%20PM.png)

## after
![wide screens](https://cl.ly/022e0G0Y1r1g/Screen%20Shot%202017-07-19%20at%207.43.07%20PM.png)