### PR TITLE
Fixes Mobile Bug

### DIFF
--- a/_assets/css/base/_layout.scss
+++ b/_assets/css/base/_layout.scss
@@ -47,7 +47,7 @@
 	}
 
 	.Main {
-		flex: 0 0 100%;
+		flex: 1 0 auto;
 		order: 1;
 		padding: 0;
 	}


### PR DESCRIPTION
Updates the `.Main` CSS rule to use flex: auto instead of flex: 100% as Safari doesn't recognize percentages as expected.
