### PR TITLE
fix(monitoring): update monitoring docs

### DIFF
--- a/_install_guide/logging.md
+++ b/_install_guide/logging.md
@@ -129,15 +129,26 @@ After configuring distributed logging make sure logs are arriving before moving 
 
 If not all the logs are showing up you can get info about the logging setup from the Docker daemon. For example to **see information about where clouddriver logs are going** you can use this command:
 
-```{% raw %}
+```
+{% raw %}
 docker inspect -f '{{.HostConfig.LogConfig}}' clouddriver
-{% endraw %}```
+{% endraw %}
+```
 
 If the log config isn't what you expect then something is wrong in the Armory Spinnaker config, and if the config is what you expect the problem is likely in your distributed logging setup.
 
 ## Monitoring Spinnaker With Datadog
 
 Spinnaker provides a monitoring container which exports metrics from the core sub-services. We'll need to add two additional containers to our docker-compose setup: `datadog` and `spinnaker-monitoring`.
+
+First, ensure the the metrics endpoint is enabled by adding the following configuration to `spinnaker-local.yml` if it isn't already present.
+
+```
+services:
+  spectator:
+    webEndpoint:
+      enabled: true
+```
 
 Add the following to `/opt/spinnaker/compose/docker-compose.override.yml`
 ```
@@ -171,6 +182,13 @@ In the configuration above `/opt/spinnaker/config/datadog_api_token.txt` is a [s
 
 ```
 API_KEY=${YOUR_DATADOG_API_KEY}
+```
+
+Add a registry entry for each service you wish to monitor in `/opt/spinnaker/config/monitoring/registry`. You'll need to create 1 file per service. The filename should correspond to the service being monitored and the contents should contain a `metrics_url` of the service. For example, an entry for monitoring Clouddriver would have a filename such as `clouddriver.yml` and the contents would be:
+
+```
+# /opt/spinnaker/config/monitoring/registry/clouddriver.yml
+metrics_url: http://clouddriver:7002/spectator/metrics
 ```
 
 Add the Spinnaker monitoring configuration file in `/opt/spinnaker/config/spinnaker-monitoring.yml`:


### PR DESCRIPTION
# Description of what was changed
there were some steps missing for enabling monitoring. the default armory install disables the spectator endpoint by default.
users also need to add entried into the registry directory to inform the monitoring agent which endpoints to poll.