### PR TITLE
fix(authn): update ldap docs

### DIFF
--- a/_install_guide/auth.md
+++ b/_install_guide/auth.md
@@ -65,7 +65,13 @@ ldap:
 See the [Spinnaker LDAP Documentation](https://www.spinnaker.io/setup/security/authorization/ldap/#user-dns)
 for more options.
 - [Enable Sticky Sessions](#enable-sticky-sessions)
+- Add the following to your environment file, typically `/opt/spinnaker/env/ha.env`
 
+```
+AUTH_ENABLED=true
+```
+
+- Restart Spinnaker `service armory-spinnaker restart`
 
 
 


### PR DESCRIPTION
# Description of what was changed
the ldap docs were missing the `AUTH_ENABLED` instructions.