### PR TITLE
Updated install_guide/adding_accounts for multiple AWS accounts to clarify AssumeRole nuance.

### DIFF
--- a/_install_guide/adding_accounts.md
+++ b/_install_guide/adding_accounts.md
@@ -79,6 +79,32 @@ correct trust policy in IAM.  Below is the trust policy you give the `SpinnakerM
         "AWS": "arn:aws:iam::987654321123:role/SpinnakerManagedProfile"
       },
       "Action": "sts:AssumeRole"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:role/SpinnakerInstanceProfile"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+Now that the target account has a `SpinnakerManagedProfile`, you will need to update the Managing account `SpinnakerInstanceProfile` `SpinnakerAssumePolicy` to add each managed account.
+
+```yaml
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Resource": [
+        "arn:aws:iam::987654321123:role/SpinnakerManagedProfile",
+        "arn:aws:iam::123456789012:role/SpinnakerManagedProfile"
+      ],
+      "Effect": "Allow"
     }
   ]
 }

--- a/_install_guide/adding_accounts.md
+++ b/_install_guide/adding_accounts.md
@@ -84,7 +84,7 @@ correct trust policy in IAM.  Below is the trust policy you give the `SpinnakerM
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::123456789012:role/SpinnakerInstanceProfile"
+        "AWS": "arn:aws:iam::987654321123:role/SpinnakerInstanceProfile"
       },
       "Action": "sts:AssumeRole"
     }


### PR DESCRIPTION
## Observed issue:
- Followed https://docs.armory.io/install-guide/adding_accounts/#adding-additional-aws-accounts
- After configuration per documentation, 403s in clouddriver were preventing healthy boot.
- 403s were ManagingAccount:role/SpinnakerInstanceProfile failing to assume role for ManagedAccount:role:SpinnakerManagedProfile

## Related:
- Found and followed CloudDriver documentation that elaborates on additional IAM Role/Policy changes that resolved this issue.
- Docs:  https://github.com/spinnaker/clouddriver/tree/9a77e558fcf63d71c1ff0b4219fedbbbc4e6f6de/clouddriver-aws#configuring-the-managing-account