### PR TITLE
ENG-2502: Document setting up AWS LB for Spinnaker

### DIFF
--- a/_spinnaker/armory_halyard.md
+++ b/_spinnaker/armory_halyard.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Armory Halyard
-order: 100
+order: 20
 ---
 {:.no_toc}
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.

--- a/_spinnaker/configure_ingress.md
+++ b/_spinnaker/configure_ingress.md
@@ -1,0 +1,107 @@
+---
+layout: post
+title: Expose Spinnaker with Ingress
+order: 30
+---
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Expose Spinnaker with an Ingress
+
+You've gotten Spinnaker [installed](/spinnaker/install) on EKS but it's not
+exposed to your organization yet.  We'll make this happen by creating a
+Kubernetes (k8s) Ingress that takes advantage of Amazon's ALB ingress
+controller.
+
+For more detailed information on options, take a look at
+[Dan Maas' Amazon EKS Ingress Guide](https://medium.com/@dmaas/amazon-eks-ingress-guide-8ec2ec940a70)
+
+### Expose the Deck and Gate Services
+
+By default, the Spinnaker services are hidden away, even from load balancers.
+So we'll need to expose the Deck and Gate services, which are the only two
+actually used by the browser.
+
+```
+$ export NAMESPACE={namespace}
+$ kubectl expose service -n ${NAMESPACE} spin-gate --type LoadBalancer \
+	--port 8084 \
+	--targetPort 8084 \
+	--name spin-gate-public
+$ kubectl expose service -n ${NAMESPACE} spin-deck --type LoadBalancer \
+	--port 9000 \
+	--targetPort 9000 \
+	--name spin-gate-public
+```
+
+You'll need to use halyard to actually configure the base URLs internally,
+since Spinnaker still thinks it's running on "localhost":
+
+```
+$ export NAMESPACE={namespace}
+$ export API_URL=$(kubectl get svc -n $NAMESPACE spin-gate-public -o jsonpath='{.status.loadBalancer.ingress[0].hostname)
+$ export UI_URL=$(kubectl get svc -n $NAMESPACE spin-deck-public -o jsonpath='{.status.loadBalancer.ingress[0].hostname)
+$ hal config security api edit --override-base-url http://${API_URL}:8084
+$ hal config security ui edit --override-base-url http://${UI_URL}:9000
+$ hal deploy apply
+```
+
+### Install the alb-ingress-controller.
+
+This tutorial takes advantage of the `aws-alb-ingress-controller` project,
+which will automatically create ALBs for your services when you create an
+ingress later.  Follow the
+[walkthrough](https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/walkthrough.md)
+to get this going first.
+
+### Create the Ingress
+
+Navigate to your EKS cluster page in the AWS console, and note down the
+subnets and security groups; fill them in below (if you have more than one,
+use quotes and separate by commas).
+
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: paul-ingress
+  namespace: paul
+  labels:
+    app: "spin"
+  annotations:
+    # trigger the alb-ingress-controller
+    kubernetes.io/ingress.class: "alb"
+
+    # set ALB parameters
+    alb.ingress.kubernetes.io/scheme: "internet-facing"
+    alb.ingress.kubernetes.io/target-type: "ip"
+    alb.ingress.kubernetes.io/security-groups: sg-eced309f
+    alb.ingress.kubernetes.io/subnets: "subnet-bbcbb8f0, subnet-8191c0f8, subnet-e7ddfdbd"
+    # We'll set up HTTPS later...
+    # alb.ingress.kubernetes.io/certificate-arn: my-acm-certificate-arn
+    # alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+
+    # allow 404s on the health check
+    alb.ingress.kubernetes.io/healthcheck-path: "/health"
+    alb.ingress.kubernetes.io/success-codes: "200,404"
+    
+spec:
+  rules:
+  - host: paul.armory.io
+    http:
+      paths:
+      - backend:
+          serviceName: spin-deck
+          servicePort: 9000
+  - host: gate.paul.armory.io 
+    http:
+      paths:
+      - backend:
+          serviceName: spin-gate
+          servicePort: 8084
+```
+
+
+

--- a/_spinnaker/configure_ingress.md
+++ b/_spinnaker/configure_ingress.md
@@ -34,8 +34,8 @@ use quotes and separate by commas).
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: paul-ingress
-  namespace: paul
+  name: demo-ingress
+  namespace: demo
   labels:
     app: "spin"
   annotations:
@@ -45,27 +45,27 @@ metadata:
     # set ALB parameters
     alb.ingress.kubernetes.io/scheme: "internet-facing"
     alb.ingress.kubernetes.io/target-type: "ip"
-    alb.ingress.kubernetes.io/security-groups: sg-eced309f
-    alb.ingress.kubernetes.io/subnets: "subnet-bbcbb8f0, subnet-8191c0f8, subnet-e7ddfdbd"
-    # We'll set up HTTPS later...
+    alb.ingress.kubernetes.io/security-groups: sg-abcdef12
+    alb.ingress.kubernetes.io/subnets: "subnet-aaaaaaaa, subnet-bbbbbbbb, subnet-cccccccc"
+    # HTTPS configuration instructions COMING SOON!
     # alb.ingress.kubernetes.io/certificate-arn: my-acm-certificate-arn
     # alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS": 443}]'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
 
-    # allow 404s on the health check
+    # allow 404s on the health check; Deck doesn't have a /health path.
     alb.ingress.kubernetes.io/healthcheck-path: "/health"
     alb.ingress.kubernetes.io/success-codes: "200,404"
     
 spec:
   rules:
-  - host: paul.armory.io
+  - host: demo.armory.io
     http:
       paths:
       - backend:
           serviceName: spin-deck
           servicePort: 9000
         path: /*
-  - host: gate.paul.armory.io 
+  - host: gate.demo.armory.io 
     http:
       paths:
       - backend:
@@ -75,12 +75,27 @@ spec:
 
 ```
 
-### Update the Internal URLs
+### Create DNS CNAMEs
 
-Spinnaker will, by default, expect to be running off `localhost` and will
-generate self-referential URLs with that URL.  Now that the public DNS
-entries are working, we need to update Spinnaker's configuration to reflect
-them:
+You should shortly see your new load balancer appear in the AWS console; you
+will need to copy the DNS name from the description.  Alternatively, you should
+also be able to edit the load balancer in Spinnaker and fine the hostname
+at the bottom of the YAML, under `status:`.  Create your CNAMEs using this
+hostname as the canonical name.  You'll need to do this for both your
+Deck and Gate hostnames (demo.armory.io and gate.demo.armory.io in this
+example), using the same canonical name.
+
+It's useful to test the names work at this point.  Point a browser to
+`gate.demo.armory.io/health` and verify you get a JSON response, and try
+`demo.armory.io` (substituting your own hostnames, of course) and verify
+you get at least some of the UI to load (it may not load completely because
+we haven't finished configuring the hostnames).
+
+### Update the Internal URLs in Spinnaker
+
+The reason your UI may not have been working completely when you tried it
+in the previous step is because Spinnaker is expecting to find Gate served
+off `localhost`.  We need to configure it to use the new hostnames:
 
 ```
 $ hal config security api edit --override-base-url http://gate.demo.armory.io
@@ -88,7 +103,14 @@ $ hal config security ui edit --override-base-url http://demo.armory.io
 $ hal deploy apply
 ```
 
-## Securing with SSL
+Once this change has settled, try hitting the Deck URL again, and verify
+everything is working.  You can now use your DNS names to access your
+Spinnaker instance.
+
+## Secure with SSL
+
+COMING SOON
+
 
 
 


### PR DESCRIPTION
Does not include SSL support yet, but has end-to-end working solution for non-SSL.