### PR TITLE
ENG-2713: Added references to standard Halyard documentation

### DIFF
--- a/_spinnaker/install.md
+++ b/_spinnaker/install.md
@@ -49,7 +49,7 @@ SUBCOMMANDS
   init
     Runs Armory installer
 ```
-All standard [halyard commands](https://www.spinnaker.io/reference/halyard/) are also available.
+From there, you can issue all your [halyard commands](https://www.spinnaker.io/reference/halyard/).
 
 ### Using Docker
 

--- a/_spinnaker/install.md
+++ b/_spinnaker/install.md
@@ -49,6 +49,7 @@ SUBCOMMANDS
   init
     Runs Armory installer
 ```
+All standard [halyard commands](https://www.spinnaker.io/reference/halyard/) are also available.
 
 ### Using Docker
 
@@ -87,7 +88,7 @@ Terminal and running:
 docker exec -it armory-halyard bash
 ```
 
-From there, you can issue all your halyard commands.
+From there, you can issue all your [halyard commands](https://www.spinnaker.io/reference/halyard/).
 
 ## Installing Armory Spinnaker
 


### PR DESCRIPTION
Updated https://docs.armory.io/spinnaker/install/ with references to standard Halyard docs (https://www.spinnaker.io/reference/halyard/).