### PR TITLE
ENG-2863: Automatically update armory halyard docker tag on each build

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,0 +1,1 @@
+halyard-armory-version: latest

--- a/_spinnaker/install.md
+++ b/_spinnaker/install.md
@@ -78,7 +78,7 @@ docker run --name armory-halyard --rm \
     -v ~/.hal:/home/spinnaker/.hal \
     -v ~/.kube:/home/spinnaker/.kube \
     -v ~/.aws:/home/spinnaker/.aws \
-    -it docker.io/armory/halyard-armory:latest
+    -it docker.io/armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}
 ```
 
 Once Armory Halyard is running, you can interact with it by opening a separate

--- a/bin/build
+++ b/bin/build
@@ -4,6 +4,11 @@ cd "$(dirname "$0")"/..
 chmod -R 777 "$(pwd)"
 rm -dfr _site
 
+# fetch latest halyard-armory docker tag
+halyard_armory_version="$(arm jenkins /job/armory/job/halyard-armory/job/master/lastSuccessfulBuild/artifact/build.properties | grep HALYARD_ARMORY_VERSION | cut -d= -f2)"
+sed "s|halyard-armory-version:.*|halyard-armory-version: $halyard_armory_version|" _data/versions.yml > _data/versions.yml.new
+mv _data/versions.yml.new _data/versions.yml
+
 docker build -t armory/documentation .
 
 docker run --rm --user="root" -v "$(pwd):/srv/jekyll" armory/documentation bash -c "jekyll build"


### PR DESCRIPTION
Each time a build of these docs is triggered in Jenkins, the build script will retrieve the latest docker tag of halyard-armory from the last successful build on master.