### PR TITLE
chore(docs):  Add updated walkthroughs for some features

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,46 @@ Make a pull-request and once its merged, Jenkins automatically puts it on S3.
 
 ### Livereload
 Install the [Livereload chrome extension](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en) if you like seeing the page auto refresh when making a change.
+
+### Adding a Section
+
+* Create a directory for your new section contents to reside, prefix the 
+directory name with an underscore (ex. `_spinnaker`, `_admin_guides`).
+
+* Add a top-level file named as your section directory, without the leading 
+underscore, but with `.md` as an extension -- copy one of the existing files
+(ex. `spinnaker.md`, `admin_guides.md`).  Updat the title, permalink, and
+collection (the last should be set to the name of your section (ex.
+`spinnaker`, `admin_guides`)
+
+* Add a section in `_config.yml` under `collections`, look at the existing
+examples:
+
+```
+collections:
+  spinnaker:
+    output: true
+    permalink: /spinnaker/:title/
+  admin_guides:
+    output: true
+    permalink: /admin-guides/:title/
+```
+
+* You'll need to add to `_includes/base/header.html` a section that provides a
+section title and iterates over the contents.  You can copy from an existing
+section and just edit two places.  In this example, you would change "Armory
+Spinnaker" to the section title of your choice, and `site.spinnaker` to 
+`site.<your section name>`.  The rest can be left as-is.
+
+```
+        <li class="Nav-list__section">
+          <h3 class="Header--tiny toggle-section-trigger js__toggle-section-trigger" tabindex="0">Armory Spinnaker</h3>
+          <ul class="toggle-section">
+            {% assign sorted_install_guide = site.spinnaker | sort: 'order' %}
+            {% for link in sorted_install_guide %}
+              <li><a class="Nav-list__link{% if page.url == link.url %} is-active{% endif %}" href="{{ link.url | relative_url }}">{{ link.title | escape }}</a></li>
+            {% endfor %}
+          </ul>
+        </li>
+```
+

--- a/_includes/components/regex_vs_wildcard.md
+++ b/_includes/components/regex_vs_wildcard.md
@@ -1,0 +1,9 @@
+> A Regular Expression ("regex") is similar to, but different than, a
+> wildcard.  You may be familiar with wildcards on your command line,
+> where <code>good*</code> would list all files that start with "good".
+> In regexes, a * character simply "matches 0 or more of the preceding
+> character" -- <code>good*</code> would then match "goo", "good", and
+> "goodddddd", but wouldn't match "goodbar".  If you need help with
+> the regex syntax, [this](https://en.wikipedia.org/wiki/Regular_expression)
+> is a good introduction.
+

--- a/_spinnaker_install_admin_guides/docker.md
+++ b/_spinnaker_install_admin_guides/docker.md
@@ -21,7 +21,7 @@ a look at the [Halyard command reference](https://www.spinnaker.io/reference/hal
 If you haven't done this yet (for example, if you've just installed Armory
 Spinnaker fresh), you'll need to enable Docker registry providers:
 
-```
+```bash
 hal config provider docker-registry enable
 ```
 
@@ -34,7 +34,7 @@ public.  In most cases, you'll be configuring a private registry and the
 authentication credentials will be required, so the options are shown here
 as an example.
 
-```
+```bash
 hal config provider docker-registry account add my-docker-registry \
   --address index.docker.io
   --repositories armory/demoapp

--- a/_spinnaker_install_admin_guides/docker.md
+++ b/_spinnaker_install_admin_guides/docker.md
@@ -1,0 +1,55 @@
+---
+layout: post
+title: Docker Registries
+order: 120
+redirect_from:
+  - /spinnaker_install_admin_guides/docker/
+---
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Configuring Docker Registries with Halyard
+
+This is a quick walkthrough of how to configure your Spinnaker to access a
+Docker registry.  Many of the commands below have additional options that
+may be useful (or possibly required).  If you need more detailed help, take
+a look at the [Halyard command reference](https://www.spinnaker.io/reference/halyard/commands/#hal-config-provider-docker-registry)
+
+### Enable Docker Registries
+
+If you haven't done this yet (for example, if you've just installed Armory
+Spinnaker fresh), you'll need to enable Docker registry providers:
+
+```
+hal config provider docker-registry enable
+```
+
+### Add a Registry (and Repositories)
+
+To add a new registry, you'll use some variation of the following command.
+This example uses a public Docker Hub registry (armory/demoapp) and actually
+would not use the `--username` or `--password` options, since the registry is
+public.  In most cases, you'll be configuring a private registry and the
+authentication credentials will be required, so the options are shown here
+as an example.
+
+```
+hal config provider docker-registry account add my-docker-registry \
+  --address index.docker.io
+  --repositories armory/demoapp
+  --username yourusername
+  --password # you'll be prompted for this interactively
+```
+
+Detailed information on all command line options can be found [here](https://www.spinnaker.io/reference/halyard/commands/#hal-config-provider-docker-registry-account-add)
+
+Note:  Some registries, like Docker Hub, require you to identify the
+repositories explicitly, like above.  Some do not (such as the Google
+Container Registry).  Further details can be found [here](https://www.spinnaker.io/setup/install/providers/docker-registry/).
+
+Amazon's ECR requires additional configuration to work properly with Spinnaker.
+[We've documented this separately.](/spinnaker-install-admin-guides/ecr-registry/)
+
+
+

--- a/_spinnaker_install_admin_guides/ecr-registry.md
+++ b/_spinnaker_install_admin_guides/ecr-registry.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Configuring an ECR as a registry
-order: 120
+order: 121
 redirect_from:
   - /admin-guides/ecr-registry/
   - /admin-guides/ecr_registry/

--- a/_spinnaker_install_admin_guides/github.md
+++ b/_spinnaker_install_admin_guides/github.md
@@ -1,0 +1,65 @@
+---
+layout: post
+title: Configure Github
+order: 125
+redirect_from:
+  - /spinnaker_install_admin_guides/github/
+---
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Configuring a Github Trigger
+
+Spinnaker pipelines can be configured to trigger when a change is committed
+to a Github repository.  This doesn't require any configuration of Spinnaker
+other than [adding a Github trigger](/spinnaker-user-guides/github/) but does
+require administration of the Github repositories to configure the webhook.
+
+The open source documentation
+[has concise instructions for configuring Github webhooks.](https://www.spinnaker.io/setup/triggers/github/)
+
+## Configuring Github as an Artifact Source
+
+If you actually want to use a file from the Github commit in your pipeline,
+you'll need to configure Github as an artifact source.  This is how you would,
+for example, reference a Helm chart from your repo for later use during
+deployment.
+
+This is just a quick walkthrough of how to configure your Spinnaker to access a
+Github repo as a source of artifacts.  Many of the commands below have
+additional options that may be useful (or possibly required).  If you need
+more detailed help, take a look at the
+[Halyard command reference](https://www.spinnaker.io/reference/halyard/commands/#hal-config-artifact-github)
+
+### Enable Github Artifacts
+
+If you haven't done this yet (for example, if you've just installed Armory
+Spinnaker fresh), you'll need to enable Github as an artifact source:
+
+```bash
+hal config features edit --artifacts true
+hal config artifact github enable
+```
+
+### Add a Github Account
+
+
+To add a new registry, you'll use some variation of the following command.
+This example uses a public Docker Hub registry (armory/demoapp) and actually
+would not use the `--username` or `--password` options, since the registry is
+public.  In most cases, you'll be configuring a private registry and the
+authentication credentials will be required, so the options are shown here
+as an example.
+
+```bash
+hal config artifact github account add changemyname \
+  --token # you'll be prompted for this interactively
+```
+
+Detailed information on all command line options can be found [here](https://www.spinnaker.io/reference/halyard/commands/#hal-config-artifact-github-account-add)
+
+Don't forget to `hal deploy apply` your changes.
+
+
+

--- a/_spinnaker_install_admin_guides/jenkins.md
+++ b/_spinnaker_install_admin_guides/jenkins.md
@@ -1,20 +1,45 @@
 ---
 layout: post
-title: Jenkins
+title: Configure Jenkins
 order: 30
 redirect_from:
   - /spinnaker_install_admin_guides/jenkins/
 ---
 
+Before you can make use of Jenkins in Spinnaker, you'll need to use Halyard
+to configure access to your Jenkins masters.
+
 {:.no_toc}
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
 
-Before you can make use of Jenkins in Spinnaker, you'll need to use Halyard
-to configure access to your Jenkins masters.
+> The Spinnaker project has more in-depth documentation on configuring Jenkins
+> in Spinnaker [here](https://www.spinnaker.io/setup/ci/jenkins/)
+
+## Enable Jenkins Support
+
+If you haven't already done it, you'll need to enable Jenkins with Halyard
+with the command below.  Don't worry if it was already enabled -- nothing bad
+will happen if you've already enabled it.
+
+```bash
+hal config ci jenkins enable
+```
 
 ## Add a Jenkins Master
 
+You can add as many Jenkins masters as needed.  Once the master is configured
+properly, Spinnaker will use the credentials provided to query for all
+available jobs and make them available in the UI for triggers and stages.
 
+```bash
+hal config ci jenkins master add my-jenkins-master \
+  --address https://jenkins.my.com/ \
+  --username myusername \
+  --password # You'll be prompted for your password interactively
+
+# Remember to apply changes!
+hal deploy apply
+```
 
 

--- a/_spinnaker_install_admin_guides/jenkins.md
+++ b/_spinnaker_install_admin_guides/jenkins.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: Jenkins
+order: 30
+redirect_from:
+  - /spinnaker_install_admin_guides/jenkins/
+---
+
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+Before you can make use of Jenkins in Spinnaker, you'll need to use Halyard
+to configure access to your Jenkins masters.
+
+## Add a Jenkins Master
+
+
+
+

--- a/_spinnaker_install_admin_guides/s3.md
+++ b/_spinnaker_install_admin_guides/s3.md
@@ -1,0 +1,62 @@
+---
+layout: post
+title: Configure S3 Artifacts
+order: 130
+redirect_from:
+  - /spinnaker_install_admin_guides/s3/
+---
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Configuring S3 as an Artifact Source
+
+If you actually want to use a file from S3 in your pipeline,
+you'll need to configure S3 as an artifact source.  This is how you would,
+for example, reference a Helm chart tarball for later use during
+deployment..
+
+This is just a quick walkthrough of how to configure your Spinnaker to access
+an S3 bucket as a source of artifacts.  Many of the commands below have
+additional options that may be useful (or possibly required).  If you need
+more detailed help, take a look at the
+[Halyard command reference](https://www.spinnaker.io/reference/halyard/commands/#hal-config-artifact-s3-account)
+
+### Enable S3 Artifacts
+
+If you haven't done this yet (for example, if you've just installed Armory
+Spinnaker fresh), you'll need to enable S3 as an artifact source:
+
+```bash
+hal config features edit --artifacts true
+hal config artifact s3 enable
+```
+
+### Add S3 Account
+
+You only need to configure the S3 credentials as an account -- all buckets
+that account has access to can be referenced after that.
+
+```bash
+hal config artifact s3 account add my-s3-account \
+  --region us-west-2 \
+  --aws-access-key-id ABCDEF01234... \
+  --aws-secret-access-key # Will be prompted for this interactively
+```
+
+> NOTE:  If you are running Armory 2.1.x or earlier, the AWS secrets configured
+> with halyard above will not work as-is; you'll want to create/edit the file
+> `~/.hal/default/service-settings/clouddriver.yml` and add the credentials as
+> environment variables:
+```yaml
+env:
+  AWS_ACCESS_KEY_ID: AKIAJ6NEJ5OLASHPPE7Q
+  AWS_SECRET_ACCESS_KEY: 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
+```
+
+Detailed information on all command line options can be found [here](https://www.spinnaker.io/reference/halyard/commands/#hal-config-artifact-s3-account-add)
+
+Don't forget to `hal deploy apply` your changes.
+
+
+

--- a/_spinnaker_install_admin_guides/s3.md
+++ b/_spinnaker_install_admin_guides/s3.md
@@ -50,8 +50,8 @@ hal config artifact s3 account add my-s3-account \
 > environment variables:
 ```yaml
 env:
-  AWS_ACCESS_KEY_ID: AKIAJ6NEJ5OLASHPPE7Q
-  AWS_SECRET_ACCESS_KEY: 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
+  AWS_ACCESS_KEY_ID: ABCDEF01234....
+  AWS_SECRET_ACCESS_KEY: LXabcdef012345...
 ```
 
 Detailed information on all command line options can be found [here](https://www.spinnaker.io/reference/halyard/commands/#hal-config-artifact-s3-account-add)

--- a/_spinnaker_user_guides/docker.md
+++ b/_spinnaker_user_guides/docker.md
@@ -1,0 +1,73 @@
+---
+layout: post
+published : true
+order: 20
+title: Working with Docker Images
+redirect_from:
+  - /spinnaker_user_guides/docker/
+---
+
+This guide includes:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+> Before you start, you'll need to [configure a Docker registry](/spinnaker-install-admin-guides/docker/) using Halyard.  If
+> you don't see your Docker registry as an option, or you're missing your
+> organization or image in the UI, you'll need to double-check your Spinnaker
+> is configured to use that registry (and/or repository)
+
+## Triggering a Pipeline with a Docker Registry Update
+
+To add a Jenkins trigger to your pipeline, go to your configurations stage and
+select "Add Trigger", then select "Docker Registry" from the Type dropdown
+menu. You should then be able to select the Registry to use, and find your
+Organization(s) and Image(s).
+
+The Tag field is optional; if left empty, any new Docker image posted to the
+registry (for that image) will trigger the pipeline.  You can enter a regular
+expression here to limit triggering to tag pattern names (for example,
+`master-.*` will only trigger when a new image with a tag starting with
+"master-" is uploaded).
+
+{% include components/regex_vs_wildcard.md %}
+
+![Add Trigger](https://cl.ly/06a9fd0344c5/Screen%252520Recording%2525202019-01-09%252520at%25252010.05%252520AM.gif)
+
+## Referencing the New Image
+
+When a new Docker image (that matches the Tag pattern, if set) is detected,
+the Docker Registry trigger will fill in some context, which can be used
+in [SpEL Expressions](https://www.spinnaker.io/guides/user/pipeline/expressions/)
+elsewhere in the pipeline (for example, in a Kubernetes manifest).
+
+If you click on the `Source` link for the pipeline that was triggered, you
+can find the `trigger` section of the JSON.  Below is a partial block of
+JSON as an example of the fields that will be filled in.
+
+```json
+  "trigger": {
+    "account": "my-docker-registry",
+    "artifacts": [
+      {
+        "name": "index.docker.io/armory/demoapp",
+        "reference": "index.docker.io/armory/demoapp:master-29",
+        "type": "docker/image",
+        "version": "master-29"
+      }
+    ],
+    "repository": "armory/demoapp",
+    "tag": "master-29",
+    "type": "docker",
+  },
+```
+
+You can reference the Docker tag that triggered the pipeline with the 
+expression `${trigger['tag']}`, which may be all you need, as in this 
+image spec line from a Kubernetes manifest:
+
+```
+- image: "docker.io/armory/demoapp:${trigger['tag']}"
+```
+
+

--- a/_spinnaker_user_guides/github.md
+++ b/_spinnaker_user_guides/github.md
@@ -1,0 +1,41 @@
+---
+layout: post
+published : true
+order: 20
+title: Working with Github
+redirect_from:
+  - /spinnaker_user_guides/github/
+---
+
+This guide includes:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Trigger a Pipeline with a Github Commit
+
+> Before you start, you'll need to [configure your Github repositories](/spinnaker-install-admin-guides/github/#configuring-a-github-trigger)
+> You'll be able to configure a pipeline trigger without having configured
+> your Github webhook, but the trigger won't fire until Spinnaker can receive
+> those calls from Github.
+
+To add a Github trigger to your pipeline, go to your configurations stage
+and select "Add Trigger", then select "Git" from the Type dropdown menu.
+Then select "github".  You can then enter your organization (ex. "armory")
+and the repository name to monitor (ex. "demoapp").  Branch and Secret
+are optional, although it's recommended you set Branch to whatever the name
+of your production branch is (usually `master`) so you only trigger pipelines
+when code is committed to the production branch.  The Branch field also
+supports regular expressions, so you can limit the trigger to several branches
+with common patterns or partial matches.
+
+{% include components/regex_vs_wildcard.md %}
+
+![Configure Github Trigger](https://cl.ly/febbddf913aa/Screen%252520Recording%2525202019-01-09%252520at%25252004.10%252520PM.gif)
+
+## Using Artifacts from Github
+
+> Before you start, you'll need to [configure Github as an artifact source](/spinnaker-install-admin-guides/github/#configuring-github-as-an-artifact-source)
+> You won't see the Github artifact type until this is configured.
+
+

--- a/_spinnaker_user_guides/s3.md
+++ b/_spinnaker_user_guides/s3.md
@@ -1,0 +1,39 @@
+---
+layout: post
+published : true
+order: 24
+title: Working with S3 Artifacts
+redirect_from:
+  - /spinnaker_user_guides/s3/
+---
+
+This guide includes:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+> Before you start, you'll need to [configure an S3 artifact account](/spinnaker-install-admin-guides/s3/) using Halyard.  If
+> you don't see an S3 option for Expected Artifacts "Match against" in the UI,
+> you'll need to double-check your Spinnaker is configured with the S3 account.
+
+## Identifying an S3 File as an Artifact
+
+On a pipeline's Configuration, you'll want to "Add Artifact".  If S3 has been
+configured, you should be able to select "S3" to "Match against".  Now all
+you should need to do is enter the object path as an S3 URL
+ (ie. "s3://mybucket/myfolder/myfile.yaml").  You will want to select "Default
+Artifact" so that, if the pipeline is run manually, it knows what file to pull
+(because the artifact won't be present in the trigger otherwise).  Note that
+you can choose a completely different path -- or even a complete different
+artifact source -- for your default artifact.
+
+## Referencing the New Image
+
+Depending on what you're using the file for, the artifact should show up as
+a possible selection in later stages.  For example, if you wanted to use the
+S3 file as a deployment manifest, you could reference it in the "Deploy
+(Manifest)" stage:
+
+![Example of S3 Manifest Artifact](https://cl.ly/451acca0a98e/Screen%252520Recording%2525202019-01-10%252520at%25252002.03%252520PM.gif)
+
+

--- a/_spinnaker_user_guides/webhooks.md
+++ b/_spinnaker_user_guides/webhooks.md
@@ -7,13 +7,18 @@ redirect_from:
   - /spinnaker_user_guides/webhooks/
 ---
 
+> Spinnaker uses "webhooks" in two ways -- as a trigger for pipeline execution,
+> and as a stage that can make arbitrary calls to another service.  If you're
+> looking for information on configuring a webhook trigger that you can use
+> to run a pipeline, the open source community [has a very good guide for that](https://www.spinnaker.io/guides/user/pipeline/triggers/webhooks/).  Below we
+> discuss the use of the Webhook stage used in pipelines.
+
 This guide includes:
 {:.no_toc}
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
 
-
-# How does Spinnaker use webhooks?
+## How does Spinnaker use webhooks?
 {:.no_toc}
 Spinnaker has a stage type called "Webhook" which allows it to call out to APIs as part of running a pipeline:
 

--- a/_spinnaker_user_guides/working-with-jenkins.md
+++ b/_spinnaker_user_guides/working-with-jenkins.md
@@ -17,25 +17,22 @@ This guide includes:
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
 
-## Triggering a pipeline with Jenkins
+> Before you start, you'll need to [configure Jenkins](/spinnaker-install-admin-guides/jenkins/) using Halyard.  If
+> you don't see Jenkins as an option, or you're not seeing the correct
+> master/job combination in the UI, you'll need to double-check your Spinnaker
+> is configured to use that resource.
 
+## Triggering a pipeline with Jenkins
 
 To add a Jenkins trigger to your pipeline, go to your configurations stage and select "add trigger", then select "Jenkins" from the Type dropdown menu. Select a Master from the Master category list and then select a Job to trigger from the pipeline.
 
-
 ![](https://d1ax1i5f2y3x71.cloudfront.net/items/333F39092F0z1o220U2U/Image%202017-03-27%20at%204.47.35%20PM.png)
-
-
 
 Note: Make sure you archive your package files and your properties file in Jenkins.
 
-
-
 ### Property File
 
-
 The property file is a way to transfer information about your build from Jenkins to Spinnaker. The file needs to be archived by the Jenkins job and should contain key value pairs.
-
 
 As an example, if you had your Jenkins job create and archive a file named `build.properties` which looks like:
 

--- a/_spinnaker_user_guides/working-with-jenkins.md
+++ b/_spinnaker_user_guides/working-with-jenkins.md
@@ -99,7 +99,7 @@ When the execution gets to the manual judgement stage, you should see the word `
 
 ![](https://d1ax1i5f2y3x71.cloudfront.net/items/1y2b0r462m2s390a1B3Q/Image%202017-03-28%20at%202.06.45%20PM.png)
 
-## Runnings scripts on Spinnaker
+## Running scripts on Spinnaker
 
 You can also run arbitrary scripts on Spinnaker (behind the scenes it is pushing this work off to a Jenkins master). Simply select the `Script` type stage while configuring a pipeline. You should see a screen like:
 


### PR DESCRIPTION
Quick-start guides for configuring things like Jenkins masters, Github and S3 artifact accounts, etc.
Configuration in Admin Guides, Usage in User Guides (which have links to the configuration guides to make sure people know what needs to be set up first)

Also added a reusable callout/note about the difference between a "regular expression" and a "wildcard" (not often a problem, but trips up enough people it seemed warranted to call out)