### PR TITLE
feat(dinghy):  Add commands for configuring Slack

### DIFF
--- a/_spinnaker/armory_halyard.md
+++ b/_spinnaker/armory_halyard.md
@@ -137,6 +137,7 @@ hal armory dinghy [parameters] [subcommands]
  * `disable`: Disable Dinghy
  * `edit`: Edit Dinghy settings
  * `enable`: Enable Dinghy
+ * `slack`: Configure Slack notifications (Halyard >= 1.6.3)
 
 ---
 ## hal armory dinghy disable
@@ -192,6 +193,52 @@ hal armory dinghy enable [parameters]
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
+---
+## hal armory dinghy slack
+
+Configure Dinghy to send processing results to a Slack channel  (Halyard >= 1.6.3)
+
+#### Usage
+```
+hal armory dinghy slack [enable|disable]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `enable`: Enable Slack notifications/edit Slack channel
+ * `disable`: Disable Slack notifications
+
+---
+## hal armory dinghy slack enable
+
+Enable Slack notifications from Dinghy (Halyard >= 1.6.3)
+
+#### Usage
+```
+hal armory dinghy slack enable [parameters]
+```
+
+#### Parameters
+ * `--channel`: If supplied, sets the channel notifications will be sent to.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+---
+## hal armory dinghy slack disable (Halyard >= 1.6.3)
+
+Disable Slack notifications from Dinghy
+
+#### Usage
+```
+hal armory dinghy slack disable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
 
 ---
 ## hal armory init

--- a/_spinnaker/armory_halyard.md
+++ b/_spinnaker/armory_halyard.md
@@ -227,9 +227,9 @@ hal armory dinghy slack enable [parameters]
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
 ---
-## hal armory dinghy slack disable (Halyard >= 1.6.3)
+## hal armory dinghy slack disable
 
-Disable Slack notifications from Dinghy
+Disable Slack notifications from Dinghy (Halyard >= 1.6.3)
 
 #### Usage
 ```

--- a/_spinnaker/install_dinghy.md
+++ b/_spinnaker/install_dinghy.md
@@ -17,7 +17,7 @@ This guide should include:
 * Setting up GitHub or Bitbucket/Stash webhooks to work with the "Pipelines as code" feature
 
 ## Overview
-To get an overview of Pipelines as code, check out the [user guide](http://docs.armory.io/spinnaker/using_dinghy)
+To get an overview of Pipelines as code, check out the [user guide](/spinnaker/using_dinghy)
 
 ## Enabling Pipelines as code
 In order to configure "Pipelines as code", it has to be enabled. Enable by running the following command:
@@ -67,4 +67,4 @@ You'll need to setup webhooks for each project that has the dinghyfile or module
 
 * If you want to disable lock pipelines in the UI before overwriting changes, add `--autolock-pipelines false`
 
-For a complete listing of options check out [hal armory](https://docs.armory.io/spinnaker/armory_halyard/#hal-armory-dinghy-edit)
+For a complete listing of options check out [hal armory](/spinnaker/armory_halyard/#hal-armory-dinghy-edit)


### PR DESCRIPTION
In Halyard 1.6.3+, you can configure Dinghy to send notifications to
Slack when a Dinghyfile has been processed (success/failure).