### PR TITLE
docs(fix): Minor documentation fixes

### DIFF
--- a/_install_guide/application_pipeline.md
+++ b/_install_guide/application_pipeline.md
@@ -57,7 +57,7 @@ _Note_: Strategy will be covered in a separate guide.
 
 ![](/images/Image 2017-03-24 at 3.50.27 PM.png)
 
-_Note_: The Property File is an important topic that will be [covered in a separate guide](http://localhost:4000/user-guides/working-with-jenkins/#property-file).
+_Note_: The Property File is an important topic that will be [covered in a separate guide](https://docs.armory.io/spinnaker-user-guides/working-with-jenkins/#property-file).
 
 #### Step 7: Before you test your pipeline, you may want to consider enabling or disabling the trigger via the checklist at the bottom.
 

--- a/_spinnaker/terraform_integration.md
+++ b/_spinnaker/terraform_integration.md
@@ -118,7 +118,7 @@ identify the artifact account.
 hal config artifact bitbucket enable
 
 # This will prompt for the password
-hal config artifact bitbucker account add bitbucket-for-terraform \
+hal config artifact bitbucket account add bitbucket-for-terraform \
   --username <USERNAME> \
   --password
 ```

--- a/_spinnaker/using_dinghy.md
+++ b/_spinnaker/using_dinghy.md
@@ -533,7 +533,7 @@ If you have already created a pipeline in the Spinnaker UI, you can create a din
 
     Save this file as `dinghyfile` in the root of your project and push it to your repository.
 
-    You may want to follow the [deleting stale pipelines](http://localhost:4000/spinnaker/using_dinghy/#deleting-stale-pipelines).
+    You may want to follow the [deleting stale pipelines](https://docs.armory.io/spinnaker/using_dinghy/#deleting-stale-pipelines).
 
 # Alternate Template Formats
 

--- a/_spinnaker_user_guides/application-pipeline.md
+++ b/_spinnaker_user_guides/application-pipeline.md
@@ -61,7 +61,7 @@ _Note_: Strategy will be covered in a separate guide.
 
 ![](/images/Image 2017-03-24 at 3.50.27 PM.png)
 
-_Note_: The Property File is an important topic that will be [covered in a separate guide](http://localhost:4000/user-guides/working-with-jenkins/#property-file).
+_Note_: The Property File is an important topic that will be [covered in a separate guide](https://docs.armory.io/spinnaker-user-guides/working-with-jenkins/#property-file).
 
 #### Step 7: Before you test your pipeline, you may want to consider enabling or disabling the trigger via the checklist at the bottom.
 


### PR DESCRIPTION
* Updating links to proper URL from localhost:4000
* Spelling error on 'Bitbucket' in Terraform documentation

Closes https://github.com/armory/documentation/issues/713.