### PR TITLE
docs(version): add recommended Spinnaker versions

### DIFF
--- a/_spinnaker/policy_engine.md
+++ b/_spinnaker/policy_engine.md
@@ -16,7 +16,7 @@ The Armory Policy Engine is designed to allow enterprises more complete control 
 Armory recommends the following versions for the Policy Engine:
 * OPA versions 0.12.x or 0.13.x
 * Halyard 1.7.2 or later
-* Spinnaker 2.16 or later
+* Spinnaker 2.16.0 or later
 
 ## Before You Start
 Keep the following guidelines in mind when using the Policy Engine: 

--- a/_spinnaker/policy_engine.md
+++ b/_spinnaker/policy_engine.md
@@ -5,16 +5,18 @@ order: 142
 ---
 
 ## Overview
-The Armory Policy Engine is designed to allow enterprises more complete control of their software delivery process by providing them with the hooks necessary to perform more extensive verification of their pipelines and processes in Spinnaker. This policy engine is backed by [Open Policy Agent](https://www.openpolicyagent.org/) and uses input style documents to perform validation of pipelines during creation and updates.
+The Armory Policy Engine is designed to allow enterprises more complete control of their software delivery process by providing them with the hooks necessary to perform more extensive verification of their pipelines and processes in Spinnaker. This policy engine is backed by [Open Policy Agent](https://www.openpolicyagent.org/)(OPA) and uses input style documents to perform validation of pipelines during creation and updates.
 
 {:.no_toc}
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
 
 ## Requirements 
-The Policy Engine has been tested with OPA versions 0.12.x and 0.13.x.
 
-Armory recommends running Halyard 1.7.2+ and Spinnaker 2.16+ to use the Policy Engine.
+Armory recommends the following versions for the Policy Engine:
+* OPA versions 0.12.x or 0.13.x
+* Halyard 1.7.2 or later
+* Spinnaker 2.16 or later
 
 ## Before You Start
 Keep the following guidelines in mind when using the Policy Engine: 

--- a/_spinnaker/policy_engine.md
+++ b/_spinnaker/policy_engine.md
@@ -12,7 +12,9 @@ The Armory Policy Engine is designed to allow enterprises more complete control 
 {:toc}
 
 ## Requirements 
-The Policy Engine has been tested with OPA versions 0.12.x and 0.13.x
+The Policy Engine has been tested with OPA versions 0.12.x and 0.13.x.
+
+Armory recommends running Halyard 1.7.2+ and Spinnaker 2.16+ to use the Policy Engine.
 
 ## Before You Start
 Keep the following guidelines in mind when using the Policy Engine: 


### PR DESCRIPTION
Discussed this with Beth because customers are asking about the required Spinnaker version. These aren't the actual minimum versions. We just know that the policy engine works on this version for sure because it was the GA version when policy engine was announced as "GA."