### PR TITLE
docs(search): Add google custom search 

### DIFF
--- a/_includes/base/header.html
+++ b/_includes/base/header.html
@@ -11,6 +11,10 @@
 
   <a href="https://spinnaker.demo.armory.io/" class="Button Button--purple mb-3">Try Our Free Demo Environment</a>
 
+  <script async src="https://cse.google.com/cse.js?cx=006551269446923101548:rlkyslvzwnj"></script>
+  <h3 class="Header--tiny">Search</h3>
+  <div class="gcse-search"></div>
+
   <nav class="Nav">
       <ul class="Nav-list">
         <li class="Nav-list__section">


### PR DESCRIPTION
This PR adds asynchronous Google Custom Search Engine functionality to the left navigation bar.  The reader types a search term in the box and either clicks the `search` icon or hits enter on the keyboard. Results from Google CSE are displayed in a pop up modal window within the browser window.

1.  Created Google custom search engine at https://cse.google.com/  for docs.armory.io; google account: aimee.ukasick@armory.io
1. Customized look at feel using CSE control panel
1. Inserted script link and google search div in _includes/base/header.html

Preview on my Netlify account:   https://deploy-preview-6--brave-panini-8017d6.netlify.com/