### PR TITLE
docs(troubleshooting): Add note about waiting until containers are running before expecting to connect

### DIFF
--- a/_spinnaker_install_admin_guides/install-on-aws.md
+++ b/_spinnaker_install_admin_guides/install-on-aws.md
@@ -482,9 +482,9 @@ Then, you can access Spinnaker at http://localhost:9000
 
 __Note:__ Even if the `hal deploy apply` command returns successfully, the 
 installation may not be complete yet. This is especially the case with 
-kubernetes distributed installs. If you see errors such as `Connection refused`
-it may be that all of the containers are not yet available. You can either wait, 
-or check the status of all of the containers using the commands for your cloud provider 
+distributed Kubernetes installs. If you see errors such as `Connection refused`,
+the containers may not be available yet. You can either wait 
+or check the status of all of the containers using the command for your cloud provider 
 (such as `kubectl get pods --namespace spinnaker`).
 
 ## Install the NGINX ingress controller

--- a/_spinnaker_install_admin_guides/install-on-aws.md
+++ b/_spinnaker_install_admin_guides/install-on-aws.md
@@ -480,6 +480,13 @@ Then, you can access Spinnaker at http://localhost:9000
 
 (If you are doing this on a remote machine, this will not work because your browser attempts to access localhost on your local workstation rather than on the remote machine where the port is forwarded)
 
+__Note:__ Even if the `hal deploy apply` command returns successfully, the 
+installation may not be complete yet. This is especially the case with 
+kubernetes distributed installs. If you see errors such as `Connection refused`
+it may be that all of the containers are not yet available. You can either wait, 
+or check the status of all of the containers using the commands for your cloud provider 
+(such as `kubectl get pods --namespace spinnaker`).
+
 ## Install the NGINX ingress controller
 
 In order to expose Spinnaker to end users, you have perform the following actions:

--- a/_spinnaker_install_admin_guides/install-on-gke.md
+++ b/_spinnaker_install_admin_guides/install-on-gke.md
@@ -391,9 +391,9 @@ Then, you can access Spinnaker at http://localhost:9000
 
 __Note:__ Even if the `hal deploy apply` command returns successfully, the 
 installation may not be complete yet. This is especially the case with 
-kubernetes distributed installs. If you see errors such as `Connection refused`
-it may be that all of the containers are not yet available. You can either wait, 
-or check the status of all of the containers using the commands for your cloud provider 
+distributed Kubernetes installs. If you see errors such as `Connection refused`,
+the containers may not be available yet. You can either wait 
+or check the status of all of the containers using the command for your cloud provider 
 (such as `kubectl get pods --namespace spinnaker`).
 
 ## Install the NGINX ingress controller

--- a/_spinnaker_install_admin_guides/install-on-gke.md
+++ b/_spinnaker_install_admin_guides/install-on-gke.md
@@ -389,6 +389,13 @@ Then, you can access Spinnaker at http://localhost:9000
 
 (If you are doing this on a remote machine, this will not work because your browser attempts to access localhost on your local workstation rather than on the remote machine where the port is forwarded)
 
+__Note:__ Even if the `hal deploy apply` command returns successfully, the 
+installation may not be complete yet. This is especially the case with 
+kubernetes distributed installs. If you see errors such as `Connection refused`
+it may be that all of the containers are not yet available. You can either wait, 
+or check the status of all of the containers using the commands for your cloud provider 
+(such as `kubectl get pods --namespace spinnaker`).
+
 ## Install the NGINX ingress controller
 
 In order to expose Spinnaker to end users, you have perform the following actions:


### PR DESCRIPTION
This note was added to the OSS doc back in December (by me). It reminds users to wait until containers are running before trying to connect to the application. This is because the hal deploy completes but the application it likely still not running. The OSS pull request was: https://github.com/spinnaker/spinnaker.github.io/pull/1609