### PR TITLE
docs(demo): remove link to demo env

### DIFF
--- a/_includes/base/header.html
+++ b/_includes/base/header.html
@@ -9,8 +9,6 @@
     <img src="/images/logo.svg" height="44" />
   </a>
 
-  <a href="https://spinnaker.demo.armory.io/" class="Button Button--purple mb-3">Try Our Free Demo Environment</a>
-
   <script async src="https://cse.google.com/cse.js?cx=006551269446923101548:rlkyslvzwnj"></script>
   <h3 class="Header--tiny">Search</h3>
   <div class="gcse-search"></div>

--- a/_install_guide/install.md
+++ b/_install_guide/install.md
@@ -11,10 +11,6 @@ order: 20
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
 
-## Try Armory's Demo Environment
-
-You can [try our Demo Environment](https://spinnaker.demo.armory.io) before installing Armory.
-
 ## Installing Armory Spinnaker In Kubernetes
 
 Armory Spinnaker can now be installed in Kubernetes. Please [answer these questions about your environment](go.armory.io/needs-analysis) so we can help you install Armory.

--- a/_spinnaker/install.md
+++ b/_spinnaker/install.md
@@ -24,10 +24,6 @@ Check out the [GitHub project](https://github.com/armory/minnaker) for more info
 
 # Installing Armory Spinnaker for Medium to Large Enterprise Deployments
 
-## Try Armory's Demo Environment
-
-You can [try our Demo Environment](https://spinnaker.demo.armory.io) before installing Armory.
-
 ## Prerequisites
 
 Make sure you have a kubernetes cluster with a minimum of **15 GB** of memory and **8 CPU's** total _available_ to be used by Spinnaker. At least a single node should have 4 GB and 1 CPU available.


### PR DESCRIPTION
Remove the mentions of the demo environment. We're directing prospects to Minnaker instead.