### PR TITLE
fix(docs): Update install-on-gke.md

### DIFF
--- a/_spinnaker_install_admin_guides/install-on-gke.md
+++ b/_spinnaker_install_admin_guides/install-on-gke.md
@@ -9,11 +9,11 @@ redirect_from:
   - /spinnaker-install-admin-guides/install_on_gke/
 ---
 
-This guide describes how to install Spinnaker in GKE.  It will create / use the following Google Cloud resources:
+This guide describes how to install Spinnaker in Googke Kubernetes Engine (GKE).  It will create / use the following Google Cloud resources:
 
 * A GKE (Google Kubernetes Engine) cluster (you can use an existing one if you already have one)
 * A GCS (Google Cloud Storage) bucket (you can use an existing one if you already have one)
-* An NGINX Ingress controller in your GKE cluster. This step is only needed if your cluster doesn't already have an ingress installed. Furthermore, the instructions provided below only work on Kubernetes version 1.14 and older. 
+* An NGINX Ingress controller in your GKE cluster. This step is only needed if your cluster doesn't already have an ingress installed. Note that the examples on this page for NGINX only work on Kubernetes version 1.14 or later. 
 
 This document currently does not fully cover the following (see [Next Steps](#next-steps) for some links to achieve these)
 
@@ -409,7 +409,7 @@ We're going to install the NGINX ingress controller on GKE because of these two 
 * It only exposes NodePort services
 * It only exposes services that respond with an `HTTP 200` to a `GET` on `/` (or have a `readinessProbe` configured)
 
-If you already have an NGINX ingress controller installed on your cluster, you may skip this step.
+If you already have an NGINX ingress controller installed on your cluster, skip this step.
 
 (Both of these are configurable with Spinnaker, but the NGINX ingress controller is also generally much more configurable)
 
@@ -421,7 +421,7 @@ Install the NGINX ingress controller components:
 kubectl --kubeconfig kubeconfig-gke apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml
 ```
 
-If you are using a Kubernetes version previous to 1.14, you need to change kubernetes.io/os to beta.kubernetes.io/os at line 217 of mandatory.yaml. See https://kubernetes.github.io/ingress-nginx/deploy/ for more details.
+If you are using a Kubernetes version earlier than 1.14, you need to change kubernetes.io/os to beta.kubernetes.io/os at line 217 of `mandatory.yaml`. See the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/) documentation for more details.
 
 Install the NGINX ingress controller GKE-specific service:
 

--- a/_spinnaker_install_admin_guides/install-on-gke.md
+++ b/_spinnaker_install_admin_guides/install-on-gke.md
@@ -13,7 +13,7 @@ This guide describes how to install Spinnaker in GKE.  It will create / use the 
 
 * A GKE (Google Kubernetes Engine) cluster (you can use an existing one if you already have one)
 * A GCS (Google Cloud Storage) bucket (you can use an existing one if you already have one)
-* An NGINX Ingress controller in your GKE cluster
+* An NGINX Ingress controller in your GKE cluster. This step is only needed if your cluster doesn't already have an ingress installed. Furthermore, the instructions provided below only work on Kubernetes version 1.14 and older. 
 
 This document currently does not fully cover the following (see [Next Steps](#next-steps) for some links to achieve these)
 
@@ -409,6 +409,8 @@ We're going to install the NGINX ingress controller on GKE because of these two 
 * It only exposes NodePort services
 * It only exposes services that respond with an `HTTP 200` to a `GET` on `/` (or have a `readinessProbe` configured)
 
+If you already have an NGINX ingress controller installed on your cluster, you may skip this step.
+
 (Both of these are configurable with Spinnaker, but the NGINX ingress controller is also generally much more configurable)
 
 From the `workstation machine` (where `kubectl` is installed):
@@ -418,6 +420,8 @@ Install the NGINX ingress controller components:
 ```bash
 kubectl --kubeconfig kubeconfig-gke apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml
 ```
+
+If you are using a Kubernetes version previous to 1.14, you need to change kubernetes.io/os to beta.kubernetes.io/os at line 217 of mandatory.yaml. See https://kubernetes.github.io/ingress-nginx/deploy/ for more details.
 
 Install the NGINX ingress controller GKE-specific service:
 
@@ -504,7 +508,7 @@ hal deploy apply
 Once the ingress is up (this may take some time), you can get the IP address for the ingress:
 
 ```bash
-$ kubectl describe -n spinnaker ingress spinnaker-nginx-ingress
+$ kubectl describe -n spinnaker-system ingress spin-ingress
 Name:             spinnaker-nginx-ingress
 Namespace:        spinnaker
 Address:          35.233.216.189


### PR DESCRIPTION
docs: Update to NGINX instructions on install guide

Updated to reflect that the NGINX ingress controller only works on K8s version 1.14 and higher and to only perform  step if cluster doesn't have one already. Also referenced the nginx docs in case of running version older than 1.14