### PR TITLE
fix(docs): bugs in AWS quickstart

### DIFF
--- a/_spinnaker/Armory-Spinnaker-Quickstart-1.md
+++ b/_spinnaker/Armory-Spinnaker-Quickstart-1.md
@@ -52,7 +52,7 @@ Need help setting this up? -  For a guided tutorial, watch the **Video Walkthrou
 
 6. Bind **"PowerUserAccess"** to "Spinnaker-Managing-Role".
 
-7. **"BaseIAM-PassRole"** (Create as inline policy on **"Spinnaker-Managing-Role"**).
+7. **"BaseIAM-PassRole"** (Create as inline policy on **"Spinnaker-Managing-Role"**). You must replace [YOUR_AWS_ACCOUNT_ID] with your actual AWS account id.
 
     ```json
 {
@@ -81,7 +81,7 @@ Need help setting this up? -  For a guided tutorial, watch the **Video Walkthrou
 
 8. Spinnaker-Managed-Role -> Trust relationship
 
-    Now, "Spinnaker-Managed-Role" must have Trust relationship with "Spinnaker-Managing-Role"
+    Now, "Spinnaker-Managed-Role" must have Trust relationship with "Spinnaker-Managing-Role". You must replace [YOUR_AWS_ACCOUNT_ID] with your actual AWS account id.
 
     ```json
 {

--- a/_spinnaker/Armory-Spinnaker-Quickstart-1.md
+++ b/_spinnaker/Armory-Spinnaker-Quickstart-1.md
@@ -31,21 +31,21 @@ Need help setting this up? -  For a guided tutorial, watch the **Video Walkthrou
 4. **"PassRole-and-Certificate"** (inline policy for Spinnaker-Managed-Role):
 
     ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": [
-                  "iam:ListServerCertificates",
-                  "iam:PassRole"
-                ],
-                "Resource": [
-                    "*"
-                ],
-                "Effect": "Allow"
-            }
-        ]
-    }
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "iam:ListServerCertificates",
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Effect": "Allow"
+        }
+    ]
+}
     ```
 
 5. Create - **"Spinnaker-Managing-Role"**.
@@ -55,28 +55,28 @@ Need help setting this up? -  For a guided tutorial, watch the **Video Walkthrou
 7. **"BaseIAM-PassRole"** (Create as inline policy on **"Spinnaker-Managing-Role"**).
 
     ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "ec2:DescribeAvailabilityZones",
-                    "ec2:DescribeRegions"
-                ],
-                "Resource": [
-                    "*"
-                ]
-            },
-            {
-                "Action": "sts:AssumeRole",
-                "Resource": [
-                    "arn:aws:iam::[YOUR_AWS_ACCOUNT_ID]:role/DevSpinnakerManagedRole"
-                ],
-                "Effect": "Allow"
-            }
-        ]
-    }
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeRegions"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Action": "sts:AssumeRole",
+            "Resource": [
+                "arn:aws:iam::[YOUR_AWS_ACCOUNT_ID]:role/DevSpinnakerManagedRole"
+            ],
+            "Effect": "Allow"
+        }
+    ]
+}
     ```
 
 8. Spinnaker-Managed-Role -> Trust relationship
@@ -84,24 +84,24 @@ Need help setting this up? -  For a guided tutorial, watch the **Video Walkthrou
     Now, "Spinnaker-Managed-Role" must have Trust relationship with "Spinnaker-Managing-Role"
 
     ```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
     {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Principal": {
-            "AWS": "arn:aws:iam::[YOUR_AWS_ACCOUNT_ID]:role/Spinnaker-Managing-Role",
-            "Service": [
-              "ecs.amazonaws.com",
-              "application-autoscaling.amazonaws.com",
-              "ecs-tasks.amazonaws.com",
-              "ec2.amazonaws.com"
-            ]
-          },
-          "Action": "sts:AssumeRole"
-        }
-      ]
+        "Effect": "Allow",
+        "Principal": {
+        "AWS": "arn:aws:iam::[YOUR_AWS_ACCOUNT_ID]:role/Spinnaker-Managing-Role",
+        "Service": [
+            "ecs.amazonaws.com",
+            "application-autoscaling.amazonaws.com",
+            "ecs-tasks.amazonaws.com",
+            "ec2.amazonaws.com"
+        ]
+        },
+        "Action": "sts:AssumeRole"
     }
+    ]
+}
     ```
 
 ### Bind Spinnaker-Managing-Role to Minnaker Instance in AWS Console

--- a/_spinnaker/Armory-Spinnaker-Quickstart-2.md
+++ b/_spinnaker/Armory-Spinnaker-Quickstart-2.md
@@ -150,8 +150,7 @@ hal config provider kubernetes account add kubeconfig-sa-eks \
   --only-spinnaker-managed true
 ```
 
-Note two things:
-* Replace `us-west-2-dev` with something that identifies your Kubernetes cluster.
+Note:
 * Update the `--kubeconfig-file` path with the correct filename.  Note that the path will be `/home/spinnaker/...` **not** `/etc/spinnaker/...`. This is because this command runs inside the Halyard container, which has local volumes mounted into it.
 
 ## Apply your changes

--- a/_spinnaker/Armory-Spinnaker-Quickstart-3.md
+++ b/_spinnaker/Armory-Spinnaker-Quickstart-3.md
@@ -132,8 +132,9 @@ spec:
 
 1. In EKS run the following commands to see nginx pods being created:  `kubectl get pods -n quickstart`.
 2. In Deck, the Spinnaker UI, navigate to the **Applications** page and see the deployment and containers there.
-    * Also, you can see the Ingress Service that was created to allow public access to your new deployment.
-3. Copy and paste the FQDN provided by AWS to test the NGINX landing page.
+    * Under **Load Balancers**, click on Apps to view the status of your service. 
+    * In the Status section on the right of the page, locate the Ingress address that was created to allow public access to your new deployment.
+3. Copy and paste the FQDN from the load balancer status section into a web browser to test the NGINX landing page.
 
 ![No CREATE Permission](/images/kubectl-validate.png)
 


### PR DESCRIPTION
fixed spacing problem with json that kept it from being cut and pasted into AWS console. Added clearer text on how to get FQDN for nginx test page for EKS deployment. Added clarity over updating account ID in json. Removed a cut/paste error from a previous AWS guide that referenced a name that was not present in this guide. **NOTE: You may want to make sure that json formats correctly with the tabs removed when the doc page is rendered. I did not test that. 