### PR TITLE
fix(docs): change from code to bash to match other formatting

### DIFF
--- a/_spinnaker/Armory-Spinnaker-Quickstart-2.md
+++ b/_spinnaker/Armory-Spinnaker-Quickstart-2.md
@@ -44,7 +44,7 @@ The Account name is arbitrary and should be a name that is an identifiable.  The
 
 2. Add the AWS provider account to Spinnaker:
 
-    ```code
+    ```bash
     hal config provider aws account add ${AWS_ACCOUNT_NAME} \
         --account-id ${ACCOUNT_ID} \
         --assume-role ${ROLE_NAME} \


### PR DESCRIPTION
This just makes this block of code look like the other bash commands to be executed. Basic formatting only. 