### PR TITLE
docs(fix): clarify Jenkins password

### DIFF
--- a/_spinnaker_install_admin_guides/jenkins.md
+++ b/_spinnaker_install_admin_guides/jenkins.md
@@ -18,63 +18,49 @@ to configure access to your Jenkins masters.
 
 ## Enable Jenkins Support
 
-If you haven't already done it, you'll need to enable Jenkins with Halyard
-with the command below.  Don't worry if it was already enabled -- nothing bad
-will happen if you've already enabled it.
+Enable Jenkins using the Halyard command: 
 
 ```bash
 hal config ci jenkins enable
 ```
 
-## Add a Jenkins Master
+## Create a User API Token in Jenkins
 
-You can add as many Jenkins masters as needed.  Once the master is configured
-properly, Spinnaker will use the credentials provided to query for all
-available jobs and make them available in the UI for triggers and stages.
-
-```bash
-hal config ci jenkins master add my-jenkins-master \
-  --address https://jenkins.my.com/ \
-  --username myusername \
-  --password # You'll be prompted for your password interactively
-
-# Remember to apply changes!
-hal deploy apply
-```
-
-## Jenkins Auth when Jenkins is configured with an Auth Provider
-If you have are trying to authenticate Spinnaker against a Jenkins master that has some third party authentication set up, you have to create an API token for Spinnaker to use as a password to authenticate against Jenkins.  This is how to do this:
+Spinnaker uses your Jenkins username and API token for authentication.
 
 1. Log into Jenkins
 2. Click on your username (in the top right)
 3. Click on "Configure" (on the left)
 4. Under the "API Token" section, click on "Add new Token", and "Generate" and record the generated token
-5. Record your username (should be in the URL for the current page - if you're at https://jenkins.domain.com/user/justin/configure, then the username is `justin`)
-6. Add the Jenkins master to Spinnaker with this (replace the environment variables with your own values):
-    ```
-    JENKINS_NAME=my-jenkins-master-2
-    USERNAME=justin
-    JENKINS_URL=https://jenkins.domain.com
-    TOKEN=1234567890abcdefghijklmnopqrstuvwx
+5. Record your username; this is the value in the current page URL between 'user' and 'configure' (http://<jenkins-url>/user/<username>/configure)
 
-    hal config ci jenkins enable
-    echo ${TOKEN} | hal config ci jenkins master add ${JENKINS_NAME} \
-        --address ${JENKINS_URL} \
-        --username ${USERNAME} \
-        --password
+## Add a Jenkins Master
 
-        # Password will be read from STDIN
-    ```
+You can add as many Jenkins masters as needed.  Once the master is configured
+properly, Spinnaker will use the credentials provided to query for all
+available jobs and display them in the UI for triggers and stages.
 
-## Troubleshooting Authentication / Connectivity
-Igor is the service that interacts with Jenkins.  If you want to test connectivity to your Jenkins master using the username and password/token, you can try test connectivity like this from a pod adjacent to Igor (Deck or Clouddriver is a good option, because they both often have `curl` built in):
+Add the Jenkins master to Spinnaker: 
 
 ```bash
-curl https://JENKINS_URL/api/json \
-    --user USERNAME:TOKEN
+hal config ci jenkins master add <jenkins-master-name> \
+  --address https://<jenkins-url>/ \
+  --username <jenkins-username> \
+  --password # You will be prompted for your Jenkins API token interactively
 ```
 
-This should return a JSON list of jobs.
+Apply your changes using ```hal deploy apply```.
+
+## Troubleshooting Authentication / Connectivity
+
+Igor is the service that interacts with Jenkins.  You can test Spinnaker-Jenkins connectivity using `curl` from another pod. The Deck or Clouddriver pod is a good option since `curl` is already installed there. 
+
+```bash
+curl https://<jenkins-url>/api/json --user <jenkins-username>:<jenkins-api-token>
+```
+
+This returns a JSON list of jobs.
+
 For example:
 
 ```bash


### PR DESCRIPTION
- Clarify that the reader must create a user-based API token in Jenkins.
- Reorder paragraphs
- Use brackets for placeholders in commands