### PR TITLE
docs(fix): remove naming requirement. requirement was for k8s v1

### DIFF
--- a/_overview/your-first-application.md
+++ b/_overview/your-first-application.md
@@ -40,7 +40,6 @@ Remember that Spinnaker considers an application to be anything you would put in
 
 Notes: 
 
-- The Name of the application cannot have hyphens, or it will interfere with the naming convention.
 - The Account(s) can include your AWS account and your Docker registry.
 - When you create an application in Spinnaker, consider it to be anything you would put into a single code repository. 
 


### PR DESCRIPTION
k8s v1 provider is deprecated. This was a requirement that came from that.

https://www.spinnaker.io/reference/providers/kubernetes-v2/#no-restrictive-naming-policies