### PR TITLE
doc(operator): Added operator configs to user guides

### DIFF
--- a/_spinnaker_user_guides/docker.md
+++ b/_spinnaker_user_guides/docker.md
@@ -12,7 +12,7 @@ This guide includes:
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
 
-> Before you start, you'll need to [configure a Docker registry](/spinnaker-install-admin-guides/docker/) using Halyard.  If
+> Before you start, you'll need to [configure a Docker registry](/spinnaker-install-admin-guides/docker/).  If
 > you don't see your Docker registry as an option, or you're missing your
 > organization or image in the UI, you'll need to double-check your Spinnaker
 > is configured to use that registry (and/or repository)

--- a/_spinnaker_user_guides/kayenta.md
+++ b/_spinnaker_user_guides/kayenta.md
@@ -65,11 +65,19 @@ be the one you referenced in the environment file.
 *Description*:  Free form text to help your coworkers know what this canary
 is doing.
 
-Note: If you see the following error `The was an error saving your config: 400` when you are trying to save your "Canary Config", try adding the following settings in `.hal/default/profiles/gate-local.yml`
+Note: If you see the following error `The was an error saving your config: 400` when you are trying to save your "Canary Config", try adding the following settings in your `SpinnakerService` manifest if you are using the Operator, or the contents of `gate` section in `.hal/default/profiles/gate-local.yml` if you are using Halyard:
 ```yaml
-services:
-  kayenta:
-    canaryConfigStore: true
+apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+  kind: SpinnakerService
+  metadata:
+    name: spinnaker
+  spec:
+    spinnakerConfig:
+      profiles:
+        gate:
+          services:
+            kayenta:
+              canaryConfigStore: true
 ```
 
 ## Groups

--- a/_spinnaker_user_guides/kayenta.md
+++ b/_spinnaker_user_guides/kayenta.md
@@ -65,7 +65,7 @@ be the one you referenced in the environment file.
 *Description*:  Free form text to help your coworkers know what this canary
 is doing.
 
-Note: If you see the following error `The was an error saving your config: 400` when you are trying to save your "Canary Config", try adding the following settings in your `SpinnakerService` manifest if you are using the Operator, or the contents of `gate` section in `.hal/default/profiles/gate-local.yml` if you are using Halyard:
+Note: If you see the following error `The was an error saving your config: 400` when you are trying to save your "Canary Config", try adding the following settings in your `SpinnakerService` manifest (**Operator**) or the to contents of `gate` section in `.hal/default/profiles/gate-local.yml` (**Halyard**):
 ```yaml
 apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
   kind: SpinnakerService

--- a/_spinnaker_user_guides/kustomize-manifests.md
+++ b/_spinnaker_user_guides/kustomize-manifests.md
@@ -28,12 +28,31 @@ Spinnaker uses the latest non-kubectl version of Kustomize.
 ## Enabling Kustomize in 2.16 (Beta)
 ​
 Kustomize can be enabled by a feature flag in 2.16.
+
+* If using Operator
+
+    Add the following settings to the `SpinnakerService` manifest:
+    
+    ```yaml
+    apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+    kind: SpinnakerService
+    metadata:
+      name: spinnaker
+    spec:
+      spinnakerConfig:    
+        profiles:
+          deck:
+            settings-local.js: |
+              window.spinnakerSettings.feature.kustomizeEnabled = true;
+    ```
 ​
-For Halyard, add the following line to `~/.hal/{DEPLOYMENT_NAME}/profiles/settings-local.js`:
+* If using Halyard
+
+    Add the following line to `~/.hal/{DEPLOYMENT_NAME}/profiles/settings-local.js`:
 ​
-```javascript
-window.spinnakerSettings.feature.kustomizeEnabled = true;
-```
+    ```javascript
+    window.spinnakerSettings.feature.kustomizeEnabled = true;
+    ```
 ​
 ## Using Kustomize
 ​
@@ -63,15 +82,35 @@ Kustomize in 2.17+ requires the [git/repo](https://www.spinnaker.io/reference/ar
 ## Enable Kustomize
 ​
 Kustomize can be enabled by a feature flag in Armory Spinnaker 2.16 and later.
-​
-For Halyard, add the following line to `~/.hal/{DEPLOYMENT_NAME}/profiles/settings-local.js`:
-​
-```javascript
-window.spinnakerSettings.feature.kustomizeEnabled = true;
-```
 
-Apply your changes to your Spinnaker deployment:  `hal deploy apply`. Wait until the pods are in a RUNNING state before proceeding.
+* If using Operator
+
+    Add the following settings to the `SpinnakerService` manifest and apply the changes:
+    
+    ```yaml
+    apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+    kind: SpinnakerService
+    metadata:
+      name: spinnaker
+    spec:
+      spinnakerConfig:    
+        profiles:
+          deck:
+            settings-local.js: |
+              window.spinnakerSettings.feature.kustomizeEnabled = true;
+    ```
+
+* If using Halyard
+
+    Add the following line to `~/.hal/{DEPLOYMENT_NAME}/profiles/settings-local.js`:
 ​
+    ```javascript
+    window.spinnakerSettings.feature.kustomizeEnabled = true;
+    ```
+
+    Apply your changes to your Spinnaker deployment:  `hal deploy apply`. Wait until the pods are in a RUNNING state before proceeding.
+​
+
 You can now use the *KUSTOMIZE* option on a _Bake (Manifest)_ stage.
 ​
 ![](/images/kustomize-enable.png)

--- a/_spinnaker_user_guides/kustomize-manifests.md
+++ b/_spinnaker_user_guides/kustomize-manifests.md
@@ -20,7 +20,7 @@ To learn more about Kustomize and how to define a `kustomization.yaml` file, see
 ​
 In the context of Spinnaker, Kustomize lets you generate a custom manifest, which can be deployed in a downstream `Deploy (Manifest)` stage. This manifest is tailored to your requirements and built on existing configurations.
 ​
-Spinnaker uses the latest non-kubectl version of Kustomize. 
+Spinnaker uses the latest non-kubectl version of Kustomize.
 ​
 
 # Kustomize in 2.16 (Beta)
@@ -29,10 +29,10 @@ Spinnaker uses the latest non-kubectl version of Kustomize.
 ​
 Kustomize can be enabled by a feature flag in 2.16.
 
-* If using Operator
+* **Operator**
 
     Add the following settings to the `SpinnakerService` manifest:
-    
+
     ```yaml
     apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
     kind: SpinnakerService
@@ -46,7 +46,7 @@ Kustomize can be enabled by a feature flag in 2.16.
               window.spinnakerSettings.feature.kustomizeEnabled = true;
     ```
 ​
-* If using Halyard
+* **Halyard**
 
     Add the following line to `~/.hal/{DEPLOYMENT_NAME}/profiles/settings-local.js`:
 ​
@@ -77,16 +77,16 @@ You can now run your pipeline and get a Kustomize rendered manifest!
 # Kustomize in 2.17 (Beta)
 ​
 ### Requirements
-Kustomize in 2.17+ requires the [git/repo](https://www.spinnaker.io/reference/artifacts/types/git-repo/) artifact type. 
+Kustomize in 2.17+ requires the [git/repo](https://www.spinnaker.io/reference/artifacts/types/git-repo/) artifact type.
 ​
 ## Enable Kustomize
 ​
 Kustomize can be enabled by a feature flag in Armory Spinnaker 2.16 and later.
 
-* If using Operator
+* **Operator**
 
     Add the following settings to the `SpinnakerService` manifest and apply the changes:
-    
+
     ```yaml
     apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
     kind: SpinnakerService
@@ -100,7 +100,7 @@ Kustomize can be enabled by a feature flag in Armory Spinnaker 2.16 and later.
               window.spinnakerSettings.feature.kustomizeEnabled = true;
     ```
 
-* If using Halyard
+* **Halyard**
 
     Add the following line to `~/.hal/{DEPLOYMENT_NAME}/profiles/settings-local.js`:
 ​
@@ -115,7 +115,7 @@ You can now use the *KUSTOMIZE* option on a _Bake (Manifest)_ stage.
 ​
 ![](/images/kustomize-enable.png)
 ​
-> **Note:** Sometimes you will need to clear the cache in your browser in order to see the new *KUSTOMIZE* option available on a _Bake (Manifest)_ stage. 
+> **Note:** Sometimes you will need to clear the cache in your browser in order to see the new *KUSTOMIZE* option available on a _Bake (Manifest)_ stage.
 
 ​
 ## Build the Pipeline
@@ -126,9 +126,9 @@ For this example, we are going to use this [kustomize public repository](https:/
 ​
 Add a **git/repo** Expected Artifact in the _Configuration_ section:
 ​
-- **Account** (Required): The `git/repo` account to use. 
+- **Account** (Required): The `git/repo` account to use.
 - **URL** (Required): The location of the Git repository.
-- **Branch** (Optional): The branch of the repository you want to use. _Defaults to  `master`._ 
+- **Branch** (Optional): The branch of the repository you want to use. _Defaults to  `master`._
 - **Subpath** (Optional): By clicking `Checkout subpath`, you can optionally pass in a relative subpath within the repository. This provides the option to checkout only a portion of the repository, thereby reducing the size of the generated artifact.
 
 ​![](/images/kustomize-expected-artifact.png)
@@ -158,7 +158,7 @@ Finally, add a **Deploy (Manifest)** stage. Make sure to select the _Manifest So
 
 ## Run the Pipeline
 ​
-After you execute the pipeline, you can see the manifest generated in YAML format by clicking on the _Baked Manifest YAML_ link: 
+After you execute the pipeline, you can see the manifest generated in YAML format by clicking on the _Baked Manifest YAML_ link:
 ​
 ![](/images/kustomize-execution.png)
 ​

--- a/_spinnaker_user_guides/s3.md
+++ b/_spinnaker_user_guides/s3.md
@@ -12,7 +12,7 @@ This guide includes:
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
 
-> Before you start, you'll need to [configure an S3 artifact account](/spinnaker-install-admin-guides/s3/) using Halyard.  If
+> Before you start, you'll need to [configure an S3 artifact account](/spinnaker-install-admin-guides/s3/).  If
 > you don't see an S3 option for Expected Artifacts "Match against" in the UI,
 > you'll need to double-check your Spinnaker is configured with the S3 account.
 

--- a/_spinnaker_user_guides/working-with-jenkins.md
+++ b/_spinnaker_user_guides/working-with-jenkins.md
@@ -17,7 +17,7 @@ This guide includes:
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
 
-> Before you start, you'll need to [configure Jenkins](/spinnaker-install-admin-guides/jenkins/) using Halyard.  If
+> Before you start, you'll need to [configure Jenkins](/spinnaker-install-admin-guides/jenkins/).  If
 > you don't see Jenkins as an option, or you're not seeing the correct
 > master/job combination in the UI, you'll need to double-check your Spinnaker
 > is configured to use that resource.


### PR DESCRIPTION
Please merge after https://github.com/armory/documentation/pull/816

This PR adds operator specific configs to docs in `User Guides` section.