### PR TITLE
docs(fix): remove private repo link

### DIFF
--- a/_spinnaker/operator.md
+++ b/_spinnaker/operator.md
@@ -22,7 +22,7 @@ Operator has two distinct modes you can install and use:
 If you want to get started quickly, install Operator and Spinnaker by running the following commands:
 
 ```
-# Pick a release from https://github.com/armory-io/spinnaker-operator/releases (or clone the repo https://github.com/armory-io/armory-operator and use the master branch for the latest development work)
+# Pick a release from https://github.com/armory-io/spinnaker-operator/releases 
 $ mkdir -p spinnaker-operator && cd spinnaker-operator
 $ RELEASE=v0.3.0 bash -c 'curl -L https://github.com/armory-io/spinnaker-operator/releases/download/${RELEASE}/manifests.tgz | tar -xz'
 


### PR DESCRIPTION
Remove the line about cloning the repo. It pointed to a private repo