### PR TITLE
docs(policy): update operator section to include config for runtime validation

### DIFF
--- a/_spinnaker/policy_engine.md
+++ b/_spinnaker/policy_engine.md
@@ -41,7 +41,12 @@ metadata:
 spec:
   spinnakerConfig:
     profiles:
-      front50: |
+      front50: | #Enables Save time validation of policies
+        armory:
+          opa:
+            enabled: true
+            url: <OPA Server URL>:<port>/v1
+      clouddriver: | #Enables Runtime validation of policies
         armory:
           opa:
             enabled: true
@@ -60,7 +65,12 @@ metadata:
 spec:
   spinnakerConfig:
     profiles:
-      front50: |
+      front50: | #Enables Save time validation of policies
+        armory:
+          opa:
+            enabled: true
+            url: http://opa.opaserver:8181/v1
+      clouddriver: | #Enables Runtime validation of policies
         armory:
           opa:
             enabled: true


### PR DESCRIPTION
2.19 adds runtime validation for Policy Engine, which requires a config in clouddriver. I followed the same pattern as the existing operator config for it but haven't had a chance to verify. 