### PR TITLE
feat(releases): adds v2.19.7

### DIFF
--- a/_release_notes/armoryspinnaker_v2.19.4.md
+++ b/_release_notes/armoryspinnaker_v2.19.4.md
@@ -29,10 +29,11 @@ This version includes an upgrade to the Spring Boot dependency. This requires yo
 
 ### Service Accounts using Fiat
 
-There is an issue creating or updating service accounts. This causes the pipeline permission feature to not work.  
+There is an issue creating or updating service accounts. This causes the pipeline permissions feature to not work.  
 
-**Affected versions**: Armory Spinnaker 2.19.6 and lower.
-**Fixed in**: Armory Spinnaker 2.19.7
+**Affected versions**: Armory Spinnaker 2.19.6 and earlier.
+
+**Fixed versions**: Armory Spinnaker 2.19.7 and later
 
 
 ## Highlighted Updates

--- a/_release_notes/armoryspinnaker_v2.19.4.md
+++ b/_release_notes/armoryspinnaker_v2.19.4.md
@@ -8,7 +8,7 @@ hidden: false
 # 04/15/20 Release Notes
 {:.no_toc}
 
-> Note: Do not upgrade to Armory Spinnaker 2.19.4 (this version). Instead, upgrade to Armory Spinnaker [2.19.6](/release-notes/armoryspinnaker_v2.19.6/) or later.
+> Note: Do not upgrade to Armory Spinnaker 2.19.4 (this version). Instead, upgrade to Armory Spinnaker [2.19.7](/release-notes/armoryspinnaker_v2.19.7/) or later.
 
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
@@ -26,7 +26,13 @@ This version includes an upgrade to the Spring Boot dependency. This requires yo
 
 
 ## Known Issues
-There are currently no known issues with this release.
+
+### Service Accounts using Fiat
+
+There is an issue creating or updating service accounts. This causes the pipeline permission feature to not work.  
+
+**Affected versions**: Armory Spinnaker 2.19.6 and lower.
+**Fixed in**: Armory Spinnaker 2.19.7
 
 
 ## Highlighted Updates

--- a/_release_notes/armoryspinnaker_v2.19.4.md
+++ b/_release_notes/armoryspinnaker_v2.19.4.md
@@ -31,7 +31,7 @@ This version includes an upgrade to the Spring Boot dependency. This requires yo
 
 There is an issue creating or updating service accounts. This causes the pipeline permissions feature to not work.  
 
-**Affected versions**: Armory Spinnaker 2.19.6 and earlier.
+**Affected versions**: Armory Spinnaker 2.19.6, 2.19.5, and 2.19.4.
 
 **Fixed versions**: Armory Spinnaker 2.19.7 and later
 

--- a/_release_notes/armoryspinnaker_v2.19.5.md
+++ b/_release_notes/armoryspinnaker_v2.19.5.md
@@ -8,7 +8,7 @@ hidden: false
 # 04/17/20 Release Notes
 {:.no_toc}
 
-> Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version](http://docs.armory.io/admin-guides/troubleshooting/#i-upgraded-spinnaker-and-it-is-no-longer-responding-how-do-i-rollback) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
+> Note: Do not upgrade to Armory Spinnaker 2.19.5 (this version). Instead, upgrade to Armory Spinnaker [2.19.7](/release-notes/armoryspinnaker_v2.19.7/) or later.
 
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
@@ -37,6 +37,13 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 
 ## Known Issues
+
+### Service Accounts using Fiat
+
+There is an issue creating or updating service accounts. This causes the pipeline permission feature to not work.  
+
+**Affected versions**: Armory Spinnaker 2.19.6 and lower.
+**Fixed in**: Armory Spinnaker 2.19.7
 
 ## Highlighted Updates
 ### Armory

--- a/_release_notes/armoryspinnaker_v2.19.5.md
+++ b/_release_notes/armoryspinnaker_v2.19.5.md
@@ -42,7 +42,7 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 There is an issue creating or updating service accounts. This causes the pipeline permissions feature to not work.  
 
-**Affected versions**: Armory Spinnaker 2.19.6 and earlier.
+**Affected versions**: Armory Spinnaker 2.19.6, 2.19.5, and 2.19.4.
 
 **Fixed versions**: Armory Spinnaker 2.19.7 and later
 

--- a/_release_notes/armoryspinnaker_v2.19.5.md
+++ b/_release_notes/armoryspinnaker_v2.19.5.md
@@ -40,10 +40,11 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ### Service Accounts using Fiat
 
-There is an issue creating or updating service accounts. This causes the pipeline permission feature to not work.  
+There is an issue creating or updating service accounts. This causes the pipeline permissions feature to not work.  
 
-**Affected versions**: Armory Spinnaker 2.19.6 and lower.
-**Fixed in**: Armory Spinnaker 2.19.7
+**Affected versions**: Armory Spinnaker 2.19.6 and earlier.
+
+**Fixed versions**: Armory Spinnaker 2.19.7 and later
 
 ## Highlighted Updates
 ### Armory

--- a/_release_notes/armoryspinnaker_v2.19.6.md
+++ b/_release_notes/armoryspinnaker_v2.19.6.md
@@ -8,7 +8,7 @@ hidden: false
 # 04/20/20 Release Notes
 {:.no_toc}
 
-> Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version](http://docs.armory.io/admin-guides/troubleshooting/#i-upgraded-spinnaker-and-it-is-no-longer-responding-how-do-i-rollback) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
+> Note: Do not upgrade to Armory Spinnaker 2.19.6 (this version). Instead, upgrade to Armory Spinnaker [2.19.7](/release-notes/armoryspinnaker_v2.19.7/) or later.
 
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
@@ -28,7 +28,13 @@ The Kubernetes V1 provider will be removed in Spinnaker 1.21. Please see the [RF
 Breaking change: Kubernetes accounts with an unspecified providerVersion will now default to V2. Update your Halconfig to specify `providerVersion: v1` for any Kubernetes accounts you are currently using with the V1 provider.
 
 ## Known Issues
-There are currently no known issues with this release.
+
+### Service Accounts using Fiat
+
+There is an issue creating or updating service accounts. This causes the pipeline permission feature to not work.  
+
+**Affected versions**: Armory Spinnaker 2.19.6 and lower.
+**Fixed in**: Armory Spinnaker 2.19.7
 
 ## Highlighted Updates
 
@@ -174,4 +180,4 @@ See the Open Source Spinnaker Release Notes for the versions included in this re
 * [Spinnaker's v1.19.4](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#spinnaker-release-1-19-4)
 * [Spinnaker's v1.19.5](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#individual-service-changes) 
 
-This version cherry-picks [spinnaker/deck/pull/8180](https://github.com/spinnaker/deck/pull/8180).
+This version cherry picks [spinnaker/deck/pull/8180](https://github.com/spinnaker/deck/pull/8180).

--- a/_release_notes/armoryspinnaker_v2.19.6.md
+++ b/_release_notes/armoryspinnaker_v2.19.6.md
@@ -31,10 +31,11 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ### Service Accounts using Fiat
 
-There is an issue creating or updating service accounts. This causes the pipeline permission feature to not work.  
+There is an issue creating or updating service accounts. This causes the pipeline permissions feature to not work.  
 
-**Affected versions**: Armory Spinnaker 2.19.6 and lower.
-**Fixed in**: Armory Spinnaker 2.19.7
+**Affected versions**: Armory Spinnaker 2.19.6 and earlier.
+
+**Fixed versions**: Armory Spinnaker 2.19.7 and later
 
 ## Highlighted Updates
 

--- a/_release_notes/armoryspinnaker_v2.19.7.md
+++ b/_release_notes/armoryspinnaker_v2.19.7.md
@@ -13,57 +13,93 @@ hidden: false
 * This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
 {:toc}
 
-<!--
 ## Breaking Changes
-<!--
-most of the time this will be empty, however we're leaving this section for a consistent format.
--->
+
+### Required Halyard version
+
+Armory Spinnaker 2.19.x requires Armory Halyard 1.8.3 or later.
+
 ### HTTP sessions for Gate
 This version includes an upgrade to the Spring Boot dependency. This requires you to flush all the Gate sessions for your Spinnaker deployment. For more information, see [Flushing Gate Sessions](https://kb.armory.io/admin/flush-gate-sessions/).
 
--->
+### Scheduled Removal of Kubernetes V1 Provider
+The Kubernetes V1 provider will be removed in Spinnaker 1.21. Please see the [RFC](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) for more details.
 
-
+Breaking change: Kubernetes accounts with an unspecified providerVersion will now default to V2. Update your Halconfig to specify `providerVersion: v1` for any Kubernetes accounts you are currently using with the V1 provider.
 
 ## Known Issues
 There are currently no known issues with this release.
 
-<!-- example format of a known issue
-### Igor wants his name to be changed to eye-gor
-Igor (pronounced "eye-gor" /ˈaɪɡɔːr/)[1] is a fictional character in the 1974 film Young Frankenstein and its 2007 musical adaptation. He is the hunchbacked assistant of Dr. Frederick Frankenstein, and the grandson of Igor, the original assistant of Frederick's grandfather, Victor Frankenstein.
-
-**Symptoms:**
-Calling eye-gor by Igor will invoke his wrath
-
-**Fix:**
-Call eye-gor by eye-gor
--->
-
-
-
 ## Highlighted Updates
+
 ### Armory
 Highlighted Updates describe some of the major changes in this release. Highlights specific to Armory Spinnaker for this release include:
 
-<!-- format should look something like this
 **Policy Engine**
 
-Armory's Policy Engine ....
-
+Armory's Policy Engine for the SDLC now also performs Runtime validation on Spinnaker pipelines. This means that when a pipeline runs, the Policy Engine evaluates the pipeline. This validation only operates on tasks that you have explicitly created policies for. For more information, see [Policy Engine](/spinnaker/policy-engine).
 
 **CVEs**
 
 Addressed a number of CVEs found within the Spinnaker services.
--->
 
+**Service Accounts using Fiat**
 
+This version includes a cherry picked commit that fixes an issue with creating or updating service accounts. The issue caused pipeline permissions to not work. 
+
+**Plugins**
+
+This release supports Plugin deployment using Armory Halyard or the [Spinnaker Operator](/_spinnaker/operator/). Consult the open source [Plugin](https://www.spinnaker.io/guides/user/plugins/user-guide/) docs for Halyard usage or the [Plugins Operator Reference](/_operator_reference/plugins/) for a manifest example.
+
+Additionally, this version of Spinnaker includes updates to how Deck is built. Previously, Deck's builds were non-deterministic, causing issues with loading plugins into the UI. Deck's builds are now deterministic and support UI plugins.
+
+**Managed Pipeline Templates v2 UI**
+
+Armory Spinnaker 2.19.x contains the latest version of Managed Pipeline Templates v2 (MPTv2), which is the default pipeline templating solution offered in OSS Spinnaker. 
+
+Armory recommends using Armory's Pipeline as Code feature instead of MPTv2 because it offers the following benefits:
+
+* Integration with GitHub, GitLab and BitBucket enabling teams to store pipelines with application code
+* Templates and access to the templates can be stored and managed separately from pipelines
+* The ability to compose complex templates and pipelines from modules
+
+Note that Armory's Pipeline as Code and the open source Managed Pipeline Templates are not integrated and do not work together.
+
+By default, the MPTv2 UI is disabled in Armory Spinnaker 2.19.6. Leaving the UI disabled maintains the same experience you had with Armory Spinnaker 2.18.x (OSS 1.18.x).
+
+If you want to enable the MPTv2 UI, see [Enabling the Managed Pipeline Templates UI](https://kb.armory.io/admin/enable-mptv2/).
 
 ###  Spinnaker Community Contributions
-The following highlights describe some of the major changes from the Spinnaker community for version OSS Release 1.19.5, which is included in this release of Armory Spinnaker 2.19:
+The following highlights describe some of the major changes from the Spinnaker community for OSS Release 1.19.5, which is included in this release of Armory Spinnaker 2.19:
 
+**Java 11**
+> The migration to Java 11 continues. This should not affect Spinnaker users. If you extend Spinnaker, this change may affect you.
 
+The Java 11 JRE runs Spinnaker when deployed to a Kubernetes cluster using Halyard (or if you consume the official containers in some other way). If this causes problems, or your organization isn't ready to run Java 11 in production, you can specify deploymentEnvironment.imageVariant: JAVA8 (or UBUNTU_JAVA8) in your Halyard config. Please notify [sig-platform@spinnaker.io](sig-platform@spinnaker.io) if you run into issues and decide to downgrade.
 
+All users need to switch to a Java 11 JRE by Spinnaker 1.21, which is scheduled to be released in early July. Please see the [RFC](https://github.com/spinnaker/governance/blob/master/rfc/java11.md) for the full schedule and more details. We encourage everyone to start testing Spinnaker under a Java 11 JRE now in preparation for the cutover. If you have any concerns about the migration timeline, please reach out to sig-platform@spinnaker.io.
 
+**IAM service-linked roles for ECS**
+
+The ECS provider now requires IAM service-linked roles for use with ECS and Application Auto Scaling. Deployments to AWS accounts that do not already have service-linked roles for these AWS services may see failed deployments after upgrading to Spinnaker 1.19. To create the required service-linked roles, run the following:
+
+```
+aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com
+aws iam create-service-linked-role --aws-service-name ecs.application-autoscaling.amazonaws.com
+```
+
+Visit the [ECS service-linked role documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html) and the [Application Auto Scaling service-linked role documentation](https://docs.aws.amazon.com/autoscaling/application/userguide/application-auto-scaling-service-linked-roles.html) for information on the permissions in these roles.
+
+**Changes to default settings for non-Halyard users**
+
+In order to make default settings consistent whether deploying using Halyard or manually, the following properties of Orca and Clouddriver have had their defaults changed. This change does not affect users who deploy using Halyard, as Halyard was already setting these properties to the new values.
+
+* Clouddriver
+  * `shutdown-wait-seconds`, which sets the number of seconds Clouddriver waits for outstanding work to complete when shutting down, will now default to 600 seconds.
+* Orca
+  * Orca will no longer consider the environment variable `REDIS_URL` when setting the connection to Redis.
+  * The setting `echo.enabled` now defaults to `true`.
+  * The `bakery.extractBuildDetails` setting now defaults to `true`.
 <br><br><br>
 
 ## Detailed Updates
@@ -134,4 +170,17 @@ artifactSources:
 ###  Spinnaker Community Contributions
 See the Open Source Spinnaker Release Notes for the versions included in this release:
 
-This version includes a fix for Fiat [spinnaker/deck/pull/8180](https://github.com/spinnaker/deck/pull/8180).
+###  Spinnaker Community Contributions
+
+See the Open Source Spinnaker Release Notes for the versions included in this release:  
+
+* [Spinnaker's v1.19.0](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#spinnaker-release-1-19-0)  
+* [Spinnaker's v1.19.1](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#spinnaker-release-1-19-1)  
+* [Spinnaker's v1.19.2](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#spinnaker-release-1-19-2)
+* [Spinnaker's v1.19.3](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#spinnaker-release-1-19-3)
+* [Spinnaker's v1.19.4](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#spinnaker-release-1-19-4)
+* [Spinnaker's v1.19.5](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#individual-service-changes) 
+
+Armory Spinnaker 2.19.6 cherry-picks [spinnaker/fiat/pull/656](https://github.com/spinnaker/fiat/pull/656).
+
+

--- a/_release_notes/armoryspinnaker_v2.19.7.md
+++ b/_release_notes/armoryspinnaker_v2.19.7.md
@@ -39,10 +39,6 @@ Highlighted Updates describe some of the major changes in this release. Highligh
 
 This version includes a cherry picked commit that fixes an issue with creating or updating service accounts. The issue caused pipeline permissions to not work. 
 
-**Affected versions**: Armory Spinnaker 2.19.6 and earlier.
-
-**Fixed versions**: Armory Spinnaker 2.19.7 and later
-
 **Policy Engine**
 
 Armory's Policy Engine for the SDLC now also performs Runtime validation on Spinnaker pipelines. This means that when a pipeline runs, the Policy Engine evaluates the pipeline. This validation only operates on tasks that you have explicitly created policies for. For more information, see [Policy Engine](/spinnaker/policy-engine).

--- a/_release_notes/armoryspinnaker_v2.19.7.md
+++ b/_release_notes/armoryspinnaker_v2.19.7.md
@@ -1,0 +1,137 @@
+---
+layout: post
+title: v2.19.7 Armory Release (OSS Release 1.19.5)
+order: -21920200421040114
+hidden: false
+---
+
+# 04/20/20 Release Notes
+{:.no_toc}
+
+> Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version](http://docs.armory.io/admin-guides/troubleshooting/#i-upgraded-spinnaker-and-it-is-no-longer-responding-how-do-i-rollback) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+<!--
+## Breaking Changes
+<!--
+most of the time this will be empty, however we're leaving this section for a consistent format.
+-->
+### HTTP sessions for Gate
+This version includes an upgrade to the Spring Boot dependency. This requires you to flush all the Gate sessions for your Spinnaker deployment. For more information, see [Flushing Gate Sessions](https://kb.armory.io/admin/flush-gate-sessions/).
+
+-->
+
+
+
+## Known Issues
+There are currently no known issues with this release.
+
+<!-- example format of a known issue
+### Igor wants his name to be changed to eye-gor
+Igor (pronounced "eye-gor" /ˈaɪɡɔːr/)[1] is a fictional character in the 1974 film Young Frankenstein and its 2007 musical adaptation. He is the hunchbacked assistant of Dr. Frederick Frankenstein, and the grandson of Igor, the original assistant of Frederick's grandfather, Victor Frankenstein.
+
+**Symptoms:**
+Calling eye-gor by Igor will invoke his wrath
+
+**Fix:**
+Call eye-gor by eye-gor
+-->
+
+
+
+## Highlighted Updates
+### Armory
+Highlighted Updates describe some of the major changes in this release. Highlights specific to Armory Spinnaker for this release include:
+
+<!-- format should look something like this
+**Policy Engine**
+
+Armory's Policy Engine ....
+
+
+**CVEs**
+
+Addressed a number of CVEs found within the Spinnaker services.
+-->
+
+
+
+###  Spinnaker Community Contributions
+The following highlights describe some of the major changes from the Spinnaker community for version OSS Release 1.19.5, which is included in this release of Armory Spinnaker 2.19:
+
+
+
+
+<br><br><br>
+
+## Detailed Updates
+
+### Bill of Materials
+Here's the bom for this version.
+<details><summary>Expand</summary>
+<pre class="highlight">
+<code>version: 2.19.7-rc.1
+timestamp: "2020-04-21 03:33:51"
+services:
+  clouddriver:
+    commit: ef9da881
+    version: 2.19.7
+  echo:
+    commit: 43e1966a
+    version: 2.19.8
+  fiat:
+    commit: 8494a0c4
+    version: 2.19.5
+  front50:
+    commit: eaeb2a64
+    version: 2.19.5
+  gate:
+    commit: 61291021
+    version: 2.19.4
+  igor:
+    commit: 8cbc70d2
+    version: 2.19.5
+  orca:
+    commit: 85dbdae9
+    version: 2.19.8
+  rosco:
+    commit: 2bb01d9e
+    version: 2.19.5
+  deck:
+    commit: 4f6b2719
+    version: 2.19.7
+  dinghy:
+    commit: ef444037
+    version: 2.19.5
+  terraformer:
+    commit: f3edd3da
+    version: 1.0.6
+  kayenta:
+    commit: c04d2e7c
+    version: 2.19.4
+  monitoring-daemon:
+    version: 0.16.1-7d506f0-rc1
+  monitoring-third-party:
+    version: 0.16.1-7d506f0-rc1
+dependencies:
+  redis:
+    version: 2:2.8.4-2
+artifactSources:
+  dockerRegistry: docker.io/armory</code>
+</pre>
+</details>
+
+
+
+### Armory
+#### Armory Fiat  - a955c640...8494a0c4
+ - fix(roles): Use snapshot fiat with the role permission fixes (#45), see [spinnaker/deck/pull/8180](https://github.com/spinnaker/deck/pull/8180)
+
+
+
+###  Spinnaker Community Contributions
+See the Open Source Spinnaker Release Notes for the versions included in this release:
+
+This version includes a fix for Fiat [spinnaker/deck/pull/8180](https://github.com/spinnaker/deck/pull/8180).

--- a/_release_notes/armoryspinnaker_v2.19.7.md
+++ b/_release_notes/armoryspinnaker_v2.19.7.md
@@ -47,6 +47,10 @@ Addressed a number of CVEs found within the Spinnaker services.
 
 This version includes a cherry picked commit that fixes an issue with creating or updating service accounts. The issue caused pipeline permissions to not work. 
 
+**Affected versions**: Armory Spinnaker 2.19.6 and earlier.
+
+**Fixed versions**: Armory Spinnaker 2.19.7 and later
+
 **Plugins**
 
 This release supports Plugin deployment using Armory Halyard or the [Spinnaker Operator](/_spinnaker/operator/). Consult the open source [Plugin](https://www.spinnaker.io/guides/user/plugins/user-guide/) docs for Halyard usage or the [Plugins Operator Reference](/_operator_reference/plugins/) for a manifest example.
@@ -181,6 +185,6 @@ See the Open Source Spinnaker Release Notes for the versions included in this re
 * [Spinnaker's v1.19.4](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#spinnaker-release-1-19-4)
 * [Spinnaker's v1.19.5](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#individual-service-changes) 
 
-Armory Spinnaker 2.19.6 cherry-picks [spinnaker/fiat/pull/656](https://github.com/spinnaker/fiat/pull/656).
+Armory Spinnaker 2.19.7 cherry-picks [spinnaker/fiat/pull/656](https://github.com/spinnaker/fiat/pull/656), which resolves an issue with Fiat and service accounts.
 
 

--- a/_release_notes/armoryspinnaker_v2.19.7.md
+++ b/_release_notes/armoryspinnaker_v2.19.7.md
@@ -35,14 +35,6 @@ There are currently no known issues with this release.
 ### Armory
 Highlighted Updates describe some of the major changes in this release. Highlights specific to Armory Spinnaker for this release include:
 
-**Policy Engine**
-
-Armory's Policy Engine for the SDLC now also performs Runtime validation on Spinnaker pipelines. This means that when a pipeline runs, the Policy Engine evaluates the pipeline. This validation only operates on tasks that you have explicitly created policies for. For more information, see [Policy Engine](/spinnaker/policy-engine).
-
-**CVEs**
-
-Addressed a number of CVEs found within the Spinnaker services.
-
 **Service Accounts using Fiat**
 
 This version includes a cherry picked commit that fixes an issue with creating or updating service accounts. The issue caused pipeline permissions to not work. 
@@ -50,6 +42,14 @@ This version includes a cherry picked commit that fixes an issue with creating o
 **Affected versions**: Armory Spinnaker 2.19.6 and earlier.
 
 **Fixed versions**: Armory Spinnaker 2.19.7 and later
+
+**Policy Engine**
+
+Armory's Policy Engine for the SDLC now also performs Runtime validation on Spinnaker pipelines. This means that when a pipeline runs, the Policy Engine evaluates the pipeline. This validation only operates on tasks that you have explicitly created policies for. For more information, see [Policy Engine](/spinnaker/policy-engine).
+
+**CVEs**
+
+Addressed a number of CVEs found within the Spinnaker services.
 
 **Plugins**
 


### PR DESCRIPTION
Open Items:
- [x] make this look pretty
- [x] add a note in versions <v2.19.7 that Creating/updating service accounts (and thus using the pipeline permissions feature) is broken
- [x] add a note to tell them to use this version.