### PR TITLE
docs(operator-ref): Indicate which parameters support encrypted

### DIFF
--- a/_operator_reference/armory.md
+++ b/_operator_reference/armory.md
@@ -65,12 +65,12 @@ armory:
 - `enabled`: true or false.
 - `templateOrg`: SCM organization or namespace where application and template repositories are located.
 - `templateRepo`: SCM repository where module templates are located
-- `githubToken`: GitHub token.
+- `githubToken`: GitHub token. Supports encrypted value.
 - `githubEndpoint`: (Default: `https://api.github.com`) Github API endpoint. Useful if you’re using Github Enterprise.
 - `stashUsername`: Stash username.
-- `stashToken`: Stash token.
+- `stashToken`: Stash token. Supports encrypted value.
 - `stashEndpoint`: Stash API endpoint.
-- `gitlabToken`: GitLab token.
+- `gitlabToken`: GitLab token.  Supports encrypted value.
 - `gitlabEndpoint`: GitLab endpoint.
 - `dinghyFilename`: (Default: `dinghyfile`) Name of the file in application repositories which contains pipelines.
 - `autoLockPipelines`: (Default: true) Lock pipelines in the UI before overwriting on change.
@@ -100,7 +100,7 @@ armory:
 - `enabled`: true or false.
 - `git`:
   - `enabled`: true or false.
-  - `accessToken`: Git access token.
+  - `accessToken`: Git access token. Supports encrypted value.
   - `username`: Git username.
 
 ## Secrets parameters

--- a/_operator_reference/artifact.md
+++ b/_operator_reference/artifact.md
@@ -144,7 +144,7 @@ gitrepo:
 
 - `username`: Git username
 - `password`: Git password. Supports encrypted value.
-- `usernamePasswordFile`: File containing "username:password" to use for Git authentication
+- `usernamePasswordFile`: File containing "username:password" to use for Git authentication. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `token`:  Git token. Supports encrypted value.
 - `tokenFile`: File containing a Git authentication token. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `sshPrivateKeyFilePath`: Path to the ssh private key in PEM format. File needs to be present on the machine running Spinnaker. Supports encrypted file.

--- a/_operator_reference/artifact.md
+++ b/_operator_reference/artifact.md
@@ -45,8 +45,8 @@ artifacts:
 ### Account parameters
 
 - `username`: Bitbucket username
-- `password`: Bitbucket password
-- `usernamePasswordFile`: File containing "username:password" to use for Bitbucket authentication
+- `password`: Bitbucket password. Supports encrypted value.
+- `usernamePasswordFile`: File containing "username:password" to use for Bitbucket authentication. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 
 Note: supply `username` and `password` OR `usernamePasswordFile`
 
@@ -65,7 +65,7 @@ gcs:
 
 ### Account parameters
 
- - `json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
+ - `json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 
 
 ## GitHub
@@ -89,10 +89,10 @@ github:
 ### Account parameters
 
  - `username`: GitHub username
- - `password`: GitHub password
- - `usernamePasswordFile`: File containing "username:password" to use for GitHub authentication
- - `token`: GitHub token
- - `tokenFile`: File containing a GitHub authentication token
+ - `password`: GitHub password. Supports encrypted value.
+ - `usernamePasswordFile`: File containing "username:password" to use for GitHub authentication. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+ - `token`: GitHub token. Supports encrypted value.
+ - `tokenFile`: File containing a GitHub authentication token. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 
 Note: supply `username` and `password` OR `usernamePasswordFile` or `token` or `tokenFile`
 
@@ -113,8 +113,8 @@ gitlab:
 
 ### Account parameters
 
- - `token`: Gitlab token
- - `tokenFile`: File containing a Gitlab authentication token
+ - `token`: Gitlab token. Supports encrypted value.
+ - `tokenFile`: File containing a Gitlab authentication token. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 
 Note: supply `token` or `tokenFile`
 
@@ -143,13 +143,13 @@ gitrepo:
 ### Account parameters
 
 - `username`: Git username
-- `password`: Git password
+- `password`: Git password. Supports encrypted value.
 - `usernamePasswordFile`: File containing "username:password" to use for Git authentication
-- `token`:  Git token
-- `tokenFile`: File containing a Git authentication token
-- `sshPrivateKeyFilePath`: Path to the ssh private key in PEM format
-- `sshPrivateKeyPassphrase`: Passphrase for encrypted private key
-- `sshKnownHostsFilePath`: File containing the known and trusted SSH hosts.
+- `token`:  Git token. Supports encrypted value.
+- `tokenFile`: File containing a Git authentication token. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+- `sshPrivateKeyFilePath`: Path to the ssh private key in PEM format. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+- `sshPrivateKeyPassphrase`: Passphrase for encrypted private key. Supports encrypted value.
+- `sshKnownHostsFilePath`: File containing the known and trusted SSH hosts. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `sshTrustUnknownHosts`: Setting this to true allows Spinnaker to authenticate with unknown hosts
 
 Note: supply `username` and `password` OR `usernamePasswordFile` or `token` or `tokenFile`
@@ -175,8 +175,8 @@ helm:
 
  - `repository`: Helm chart repository
  - `username`: Helm chart repository basic auth username
- - `password`: Helm chart repository basic auth password
- - `usernamePasswordFile`: File containing "username:password" to use for helm chart repository basic auth
+ - `password`: Helm chart repository basic auth password. Supports encrypted value.
+ - `usernamePasswordFile`: File containing "username:password" to use for helm chart repository basic auth. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 
 Note: supply `username` and `password` OR `usernamePasswordFile`
 
@@ -199,8 +199,8 @@ http:
 ### Account parameters
 
  - `username`: HTTP basic auth username
- - `password`: HTTP basic auth password
- - `usernamePasswordFile`: File containing "username:password" to use for HTTP basic auth
+ - `password`: HTTP basic auth password. Supports encrypted value.
+ - `usernamePasswordFile`: File containing "username:password" to use for HTTP basic auth. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 
 Note: supply `username` and `password` OR `usernamePasswordFile`
 
@@ -246,8 +246,8 @@ oracle:
 - `region`: An Oracle region (e.g., us-phoenix-1)
 - `userId`:  Provide the OCID of the Oracle User you're authenticating as
 - `fingerprint`:  Fingerprint of the public key
-- `sshPrivateKeyFilePath`:  Path to the private key in PEM format
-- `privateKeyPassphrase`:  Passphrase used for the private key, if it is encrypted
+- `sshPrivateKeyFilePath`:  Path to the private key in PEM format. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+- `privateKeyPassphrase`:  Passphrase used for the private key, if it is encrypted. Supports encrypted value.
 - `tenancyId`: Provide the OCID of the Oracle Tenancy to use.
 
 ## S3
@@ -272,7 +272,7 @@ s3:
 - `apiRegion`: S3 api region; only required when using an S3 clone such as Minio
 - `region`: S3 region
 - `awsAccessKeyId`: Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
-- `awsSecretAccessKey`: Your AWS Secret Key.
+- `awsSecretAccessKey`: Your AWS Secret Key. Supports encrypted value.
 
 ## Templates
 
@@ -282,4 +282,4 @@ templates:
   templatePath:
  ```
 
-`templatePath`: The path to the Jinja template to use for artifact extraction
+`templatePath`: The path to the Jinja template to use for artifact extraction. File needs to be present on the machine running Spinnaker.

--- a/_operator_reference/canary.md
+++ b/_operator_reference/canary.md
@@ -86,7 +86,7 @@ canary:
         - `profileName`: The profile name to use when resolving AWS credentials. Typically found in ~/.aws/credentials (Default: default).
         - `endpoint`: The endpoint used to reach the service implementing the AWS api. Typical use is with Minio.
         - `accessKeyId`: The default access key used to communicate with AWS.
-        - `secretAccessKey`: The secret key used to communicate with AWS.
+        - `secretAccessKey`: The secret key used to communicate with AWS. Supports encrypted value.
         - `supportedTypes`: One of: `METRICS_STORE`, `METRICS_STORE`, `OBJECT_STORE`
             - METRICS_STORE
             - CONFIGURATION_STORE
@@ -116,8 +116,8 @@ canary:
       - `name`: account name
         - `endpoint`:
           - `baseUrl`: (*Required*) The base URL to the Datadog server.
-        - `apiKey`: (*Required*) Your org's unique Datadog API key. See https://app.datadoghq.com/account/settings#api.
-        - `applicationKey`: (*Required*) Your Datadog application key. See https://app.datadoghq.com/account/settings#api.
+        - `apiKey`: (*Required*) Your org's unique Datadog API key. See https://app.datadoghq.com/account/settings#api. Supports encrypted value.
+        - `applicationKey`: (*Required*) Your Datadog application key. See https://app.datadoghq.com/account/settings#api. Supports encrypted value.
         - `supportedTypes`: One of: `METRICS_STORE`, `METRICS_STORE`, `OBJECT_STORE`
             - METRICS_STORE
             - CONFIGURATION_STORE
@@ -149,7 +149,7 @@ canary:
   - `accounts`:`
       - `name`: account name
         - `project`: (*Required*) The Google Cloud Platform project the canary service will use to consume GCS and Stackdriver.
-        - `jsonPath`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See https://cloud.google.com/compute/docs/access/service-accounts for more information.
+        - `jsonPath`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See https://cloud.google.com/compute/docs/access/service-accounts for more information. File needs to be present on the machine running Spinnaker. Supports encrypted file.
         - `bucket`: The name of a storage bucket that your specified account has access to. If you specify a globally unique bucket name that doesn't exist yet, Kayenta will create that bucket for you.
         - `bucketLocation`: This is only required if the bucket you specify doesn't exist yet. In that case, the bucket will be created in that location. See https://cloud.google.com/storage/docs/managing-buckets#manage-class-location.
         - `rootFolder`: The root folder in the chosen bucket to place all of the canary service's persistent data in (Default: kayenta).
@@ -184,8 +184,8 @@ canary:
       - `name`: account name
         - `endpoint`:
           - `baseUrl`: (*Required*) The base URL to the New Relic Insights server.
-        - `apiKey`: (*Required*) Your account's unique New Relic Insights API key. See https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api.
-        - `applicationKey`: (*Required*) Your New Relic account id. See https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id.
+        - `apiKey`: (*Required*) Your account's unique New Relic Insights API key. See https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api. Supports encrypted value.
+        - `applicationKey`: (*Required*) Your New Relic account id. See https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id. Supports encrypted value.
         - `supportedTypes`: One of: `METRICS_STORE`, `CONFIGURATION_STORE`, `OBJECT_STORE`
             - METRICS_STORE
             - CONFIGURATION_STORE
@@ -218,7 +218,7 @@ canary:
           - `baseUrl`: (*Required*) The base URL to the Prometheus server.
         - `username`: A basic auth username.
         - `password`: A basic auth password.
-        - `usernamePasswordFile`: The path to a file containing "username:password".
+        - `usernamePasswordFile`: The path to a file containing "username:password". File needs to be present on the machine running Spinnaker. Supports encrypted file.
         - `supportedTypes`: One of: `METRICS_STORE`, `CONFIGURATION_STORE`, `OBJECT_STORE`
             - METRICS_STORE
             - CONFIGURATION_STORE
@@ -249,7 +249,7 @@ canary:
       - `name`: account name
         - `endpoint`:
           - `baseUrl`: The base URL to the SignalFx server. Defaults to https://stream.signalfx.com
-        - `accessToken`: (*Required*) The SignalFx access token.
+        - `accessToken`: (*Required*) The SignalFx access token. Supports encrypted value.
         - `defaultScopeKey`: Scope key is used to distinguish between base and canary deployments. If omitted every request must supply the `_scope_key` param in extended scope params
         - `defaultLocationKey`: Location key is used to filter by deployment region. If omitted requests must supply the `_location_key` if it is needed.
         - `supportedTypes`: One of: `METRICS_STORE`, `CONFIGURATION_STORE`, `OBJECT_STORE`

--- a/_operator_reference/ci.md
+++ b/_operator_reference/ci.md
@@ -65,7 +65,7 @@ concourse:
     - `WRITE`: A user must have at least one of these roles in order to be able to run jobs on this build master.
 - `url`: (*Required*)  The url your concourse search is reachable at.
 - `username`: (*Required*)  The username of the concourse user to authenticate as.
-- `password`: (*Required*) The password of the concourse user to authenticate as.
+- `password`: (*Required*) The password of the concourse user to authenticate as. Supports encrypted value.
 
 # Google CloudBuild (gcb)
 
@@ -127,11 +127,11 @@ jenkins:
    - `READ`: A user must have at least one of these roles in order to view this build master or use it as a trigger source.
 - `address`: (*Required*) The address your Jenkins master is reachable at.
 - `username`: The username of the Jenkins user to authenticate as.
-- `password`: The password of the Jenkins user to authenticate as.
+- `password`: The password of the Jenkins user to authenticate as. Supports encrypted value.
 - `csrf`:  Whether or not to negotiate CSRF tokens when calling Jenkins.
-- `trustStore`:
+- `trustStore`: File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `trustStoreType`:
-- `trustStorePassword`:
+- `trustStorePassword`: Supports encrypted value.
 
 # Travis
 
@@ -164,7 +164,7 @@ travis:
    - `WRITE`: A user must have at least one of these roles in order to be able to run jobs on this build master.
 - `address`: (*Required*) The address of the Travis API.
 - `baseUrl`: (*Required*) The base URL to the Travis UI.
-- `githubToken`: The github token to authenticate against Travis with.
+- `githubToken`: The github token to authenticate against Travis with. Supports encrypted value.
 - `numberOfRepositories`: How many repositories the Travis integration should fetch from the api each time the poller runs. Should be set a bit higher than the expected maximum number of repositories built within the poll interval.
 
 
@@ -198,4 +198,4 @@ wercker:
    - `WRITE`: A user must have at least one of these roles in order to be able to run jobs on this build master.
 - `address`: (*Required*) The address your Wercker master is reachable at.
 - `user`: The username of the Wercker user to authenticate as.
-- `token`: The personal token of the Wercker user to authenticate as.
+- `token`: The personal token of the Wercker user to authenticate as. Supports encrypted value.

--- a/_operator_reference/ci.md
+++ b/_operator_reference/ci.md
@@ -94,7 +94,7 @@ gcb:
    - `READ`: A user must have at least one of these roles in order to view this build master or use it as a trigger source.
 - `project`: (*Required*) The name of the GCP project in which to trigger and monitor builds.
 - `subscriptionName`: The name of the PubSub subscription on which to listen for build changes.
-- `jsonKey`: The path to a JSON service account that Spinnaker will use as credentials.
+- `jsonKey`: The path to a JSON service account that Spinnaker will use as credentials. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 
 # Jenkins
 

--- a/_operator_reference/metricstores.md
+++ b/_operator_reference/metricstores.md
@@ -58,8 +58,8 @@ metricStores:
 ## Datadog
 
 - `enabled`: true or false.
-- `api_key`: Your datadog API key.
-- `app_key`: Your datadog app key. This is only required if you want Spinnaker to push pre-configured Spinnaker dashboards to your Datadog account.
+- `api_key`: Your datadog API key. Supports encrypted value.
+- `app_key`: Your datadog app key. This is only required if you want Spinnaker to push pre-configured Spinnaker dashboards to your Datadog account. Supports encrypted value.
 - `tags`: Your datadog custom tags. Please delimit the KVP with colons, e.g. `app:test` `env:dev`
 
 ## Stackdriver
@@ -73,6 +73,6 @@ metricStores:
 ## New Relic
 
 - `enabled`: true or false.
-- `insert_key`: Your New Relic Insights insert key
+- `insert_key`: Your New Relic Insights insert key. Supports encrypted value.
 - `host`: The URL to post metric data to. In almost all cases, this is set correctly by default and should not be used.
 - `tags`: Your custom tags. Please delimit the KVP with colons, e.g. `app:test` `env:dev`

--- a/_operator_reference/metricstores.md
+++ b/_operator_reference/metricstores.md
@@ -65,7 +65,7 @@ metricStores:
 ## Stackdriver
 
 - `enabled`: true or false.
-- `credentials_path`: A path to a Google JSON service account that has permission to publish metrics.
+- `credentials_path`: A path to a Google JSON service account that has permission to publish metrics. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `project`: The project Spinnaker's metrics should be published to.
 - `zone`: The zone Spinnaker's metrics should be associated with.
 - `instance_id`:

--- a/_operator_reference/notification.md
+++ b/_operator_reference/notification.md
@@ -36,7 +36,7 @@ notifications:
 
 - `enabled`: true or false.
 - `botName`: The name of your Slack bot.
-- `token`: Your Slack bot token.
+- `token`: Your Slack bot token. Supports encrypted value.
 - `baseUrl`: Slack endpoint. Optional, only set if using a compatible API.
 - `forceUseIncomingWebhook`: true or false. Force usage of incoming webhooks endpoint for Slack. Optional, only set if using a compatible API.
 
@@ -46,9 +46,9 @@ notifications:
 - `account`: Your Twilio account SID.
 - `baseUrl`: Twilio REST API base url
 - `from`: The phone number from which the SMS will be sent (e.g. +1234-567-8910).
-- `token`: Your Twilio auth token.
+- `token`: Your Twilio auth token. Supports encrypted value.
 
 ## GitHub status parameters
 
 - `enabled`: true or false.
-- `token`: Your GitHub account token.
+- `token`: Your GitHub account token. Supports encrypted value.

--- a/_operator_reference/persistent-storage.md
+++ b/_operator_reference/persistent-storage.md
@@ -38,7 +38,7 @@ azs:
 ```
 
 - `storageAccountName`: The name of an Azure Storage Account used for Spinnaker's persistent data.
-- `storageAccountKey`: The key to access the Azure Storage Account used for Spinnaker's persistent data.
+- `storageAccountKey`: The key to access the Azure Storage Account used for Spinnaker's persistent data. Supports encrypted value.
 - `storageContainerName`: (Default: `spinnaker`) The container name in the chosen storage account to place all of Spinnaker's persistent data.
 
 ## GCS
@@ -52,7 +52,7 @@ gcs:
   bucketLocation:
 ```
 
-- `jsonPath`: A path to a JSON service account with permission to read and write to the bucket to be used as a backing store.
+- `jsonPath`: A path to a JSON service account with permission to read and write to the bucket to be used as a backing store. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `project`: The Google Cloud Platform project you are using to host the GCS bucket as a backing store.
 - `bucket`: The name of a storage bucket that your specified account has access to. If not specified, a random name will be chosen. If you specify a globally unique bucket name that doesn't exist yet, Halyard will create that bucket for you.
 - `rootFolder`: The root folder in the chosen bucket to place all of Spinnaker's persistent data in.
@@ -79,8 +79,8 @@ oracle:
 - `region`: An Oracle region (e.g., us-phoenix-1)
 - `userId`: Provide the OCID of the Oracle User you're authenticating as
 - `fingerprint`: Fingerprint of the public key
-- `sshPrivateKeyFilePath`: Path to the private key in PEM format
-- `privateKeyPassphrase`: Passphrase used for the private key, if it is encrypted
+- `sshPrivateKeyFilePath`: Path to the private key in PEM format. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+- `privateKeyPassphrase`: Passphrase used for the private key, if it is encrypted. Supports encrypted value.
 - `tenancyId`: Provide the OCID of the Oracle Tenancy to use.
 
 ## S3
@@ -104,4 +104,4 @@ s3:
 - `endpoint`: An alternate endpoint that your S3-compatible storage can be found at. This is intended for self-hosted storage services with S3-compatible APIs, e.g. Minio. If supplied, this storage type cannot be validated.
 - `accessKeyId`: Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
 - `serverSideEncryption`: Use Amazon Server-Side Encryption ('x-amz-server-side-encryption' header). Supports 'AES256' (for Amazon S3-managed encryption keys, equivalent to a header value of 'AES256') and 'AWSKMS' (for AWS KMS-managed encryption keys, equivalent to a header value of 'aws:kms'.
-- `secretAccessKey`: Your AWS Secret Key.
+- `secretAccessKey`: Your AWS Secret Key. Supports encrypted value.

--- a/_operator_reference/providers.md
+++ b/_operator_reference/providers.md
@@ -74,9 +74,9 @@ appengine:
  - `cachingIntervalSeconds`: The interval in seconds at which Spinnaker will poll for updates in your AppEngine clusters.
  - `environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  - `gcloudReleaseTrack`: The gcloud release track (ALPHA, BETA, or STABLE) that Spinnaker will use when deploying to App Engine.
- - `gitHttpsPassword`: A password to be used when connecting with a remote git repository server over HTTPS.
+ - `gitHttpsPassword`: A password to be used when connecting with a remote git repository server over HTTPS. Supports encrypted value.
  - `gitHttpsUsername`: A username to be used when connecting with a remote git repository server over HTTPS.
- - `githubOAuthAccessToken`: An OAuth token provided by Github for connecting to  a git repository over HTTPS. See [Creating an Access Token for Command Line Use](https://help.github.com/articles/creating-an-access-token-for-command-line-use) for more information.
+ - `githubOAuthAccessToken`: An OAuth token provided by Github for connecting to  a git repository over HTTPS. See [Creating an Access Token for Command Line Use](https://help.github.com/articles/creating-an-access-token-for-command-line-use) for more information. Supports encrypted value.
  - `json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [Service Accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
  - `localRepositoryDirectory`: A local directory to be used to stage source files for App Engine deployments within Spinnaker's Clouddriver microservice.
  - `omitServices`: A list of regular expressions. Any service matching one of these regexes will be ignored by Spinnaker.
@@ -90,9 +90,9 @@ appengine:
  - `providerVersion`:
  - `requiredGroupMembership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  - `services`: A list of regular expressions. Any service matching one of these regexes will be indexed by Spinnaker.
- - `sshKnownHostsFilePath`: The path to a known_hosts file to be used when connecting with a remote git repository over SSH.
- - `sshPrivateKeyFilePath`: The path to an SSH private key to be used when connecting with a remote git repository over SSH.
- - `sshPrivateKeyPassphrase`: The passphrase to an SSH private key to be used when connecting with a remote git repository over SSH.
+ - `sshKnownHostsFilePath`: The path to a known_hosts file to be used when connecting with a remote git repository over SSH. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+ - `sshPrivateKeyFilePath`: The path to an SSH private key to be used when connecting with a remote git repository over SSH. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+ - `sshPrivateKeyPassphrase`: The passphrase to an SSH private key to be used when connecting with a remote git repository over SSH. Supports encrypted value.
  - `sshTrustUnknownHosts`: (*Default*: `false`) Enabling this flag will allow Spinnaker to connect with a remote git repository over SSH without verifying the server's IP address against a known_hosts file.
  - `versions`: A list of regular expressions. Any version matching one of these regexes will be indexed by Spinnaker.
 
@@ -176,7 +176,7 @@ The AWS provider requires a central "Managing Account" to authenticate on behalf
 - `defaultRegions`: array of `name: <region-name>` items
 - `features`: configuration for AWS-specific features
 - `primaryAccount`: the account you want to be primary of the configured accounts
-- `secretAccessKey`: AWS Secret Key; note that if you are baking AMIs via Rosco, you may also need to set the secret key on the AWS bakery default options.
+- `secretAccessKey`: AWS Secret Key; note that if you are baking AMIs via Rosco, you may also need to set the secret key on the AWS bakery default options. Supports encrypted value.
 
 ### Account parameters
 
@@ -206,7 +206,7 @@ The AWS provider requires a central "Managing Account" to authenticate on behalf
 
 - `awsAccessKey`: The default access key used to communicate with AWS.
 - `awsAssociatePublicIpAddress`: If using a non-default VPC, public IP addresses are not provided by default. If this is enabled, your new instance will get a Public IP.
-- `awsSecretKey`: The secret key used to communicate with AWS.
+- `awsSecretKey`: The secret key used to communicate with AWS. Supports encrypted value.
 - `awsSubnetId`: If using VPC, the default ID of the subnet, such as subnet-12345def, where Packer will launch the EC2 instance. This field is required if you are using a non-default VPC.
 - `awsVpcId`: If launching into a VPC subnet, Packer needs the VPC ID in order to create a temporary security group within the VPC. Requires subnet_id to be set. If this default value is left blank, Packer will try to get the VPC ID from the subnet_id.
 - `baseImages`: `[]`        
@@ -288,7 +288,7 @@ azure:
 
 ### Account parameters
 
-- `appKey`: (*Required*)  The appKey (password) of your service principal.
+- `appKey`: (*Required*)  The appKey (password) of your service principal. Supports encrypted value.
 - `clientId`: (*Required*) The clientId (also called appId) of your service principal.
 - `defaultKeyVault`: (*Required*) The name of a KeyVault that contains the user name, password, and ssh public key used to create VMs
 - `defaultResourceGroup`: (*Required*) The default resource group to contain any non-application specific resources.
@@ -359,7 +359,7 @@ cloudfoundry:
  - `appsManagerUrl`: HTTP(S) URL of the Apps Manager application for the CloudFoundry Foundation. Example: `https://apps.sys.somesystem.com`
  - `environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  - `metricsUrl`: HTTP(S) URL of the metrics application for the CloudFoundry Foundation. Example `https://metrics.sys.somesystem.com`
- - `password`: (*Required*) Password for the account to use on for this CloudFoundry Foundation
+ - `password`: (*Required*) Password for the account to use on for this CloudFoundry Foundation. Supports encrypted value.
  - `permissions`:
      - `READ`: `[]` A user must have at least one of these roles in order to view this account's cloud resources.
      - `WRITE`: `[]` A user must have at least one of these roles in order to make changes to this account's cloud resources.
@@ -415,8 +415,8 @@ dcos:
 
  - `clusters`: (*Required*) The clusters against which this account will authenticate.
    - `name`: (*Required*) The name of the account.
-   - `password`: Password for a user account. If set, `serviceKeyFile` should not be set.
-   - `serviceKeyFile`: Path to a file containing the secret key for service account authentication. If set, `password` should not be set.
+   - `password`: Password for a user account. If set, `serviceKeyFile` should not be set. Supports encrypted value.
+   - `serviceKeyFile`: Path to a file containing the secret key for service account authentication. If set, `password` should not be set. File needs to be present on the machine running Spinnaker. Supports encrypted file.
    - `uid`:  (*Required*) User or service account identifier.
  - `dockerRegistries`: `[]`; (*Required*) Provide the list of docker registries to use with this DC/OS account
  - `environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
@@ -428,7 +428,7 @@ dcos:
 ### Clusters parameters
 
 - `name`: (*Required*)  The name of the cluster.
-- `caCertFile`: Root certificate file to trust for connections to the cluster
+- `caCertFile`: Root certificate file to trust for connections to the cluster. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `dcosUrl`: (*Required*) URL of the endpoint for the DC/OS cluster's admin router.
 - `insecureSkipTlsVerify`:  If true, disables verification of certificates from the cluster (insecure).
 - `loadBalancer`: Configuration for a DC/OS load balancer
@@ -487,9 +487,9 @@ dockerRegistry:
 - `environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
 - `insecureRegistry`: (*Default*: `false`) Treat the docker registry as insecure (don't validate the ssl cert).
 - `paginateSize`: (*Default*: `100`) Paginate size for the docker repository `_catalog` endpoint.
-- `password`:  Your docker registry password
+- `password`:  Your docker registry password. Supports encrypted value.
 - `passwordCommand`: Command to retrieve docker token/password, commands must be available in environment
-- `passwordFile`: The path to a file containing your docker password in plaintext (not a docker/config.json file)
+- `passwordFile`: The path to a file containing your docker password in plaintext (not a docker/config.json file). File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `permissions`:
    - `READ`: `[]` A user must have at least one of these roles in order to view this account's cloud resources.
    - `WRITE`: `[]` A user must have at least one of these roles in order to make changes to this account's cloud resources.
@@ -614,7 +614,7 @@ google:
 - `alphaListed`: (*Default*: `false`) Enable this flag if your project has access to alpha features and you want Spinnaker to take advantage of them.
 - `environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
 - `imageProjects`: (*Default*: `[]`) A list of Google Cloud Platform projects Spinnaker will be able to cache and deploy images from. When this is omitted, it defaults to the current project. Each project must have granted the IAM role `compute.imageUser` to the service account associated with the json key used by this account, as well as to the 'Google APIs service account' automatically created for the project being managed (should look similar to `12345678912@cloudservices.gserviceaccount.com`). See [Sharing Images Across Projects](https://cloud.google.com/compute/docs/images/sharing-images-across-projects) for more information about sharing images across GCP projects.
-- `jsonPath`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [https://cloud.google.com/compute/docs/access/service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
+- `jsonPath`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [https://cloud.google.com/compute/docs/access/service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `permissions`:
     - `READ`: `[]` A user must have at least one of these roles in order to view this account's cloud resources.
     - `WRITE`: `[]` A user must have at least one of these roles in order to make changes to this account's cloud resources.
@@ -624,7 +624,7 @@ google:
 - `project`: (*Required*) The Google Cloud Platform project this Spinnaker account will manage.
 - `readPermissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
 - `regions`: A list of regions for caching and mutating calls. This overwrites any default-regions set on the provider.
-- `userDataFile`: The path to user data template file. Spinnaker has the ability to inject userdata into generated instance templates. The mechanism is via a template file that is token replaced to provide some specifics about the deployment. See [https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/UserData.md](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/UserData.md) for more information.
+- `userDataFile`: The path to user data template file. Spinnaker has the ability to inject userdata into generated instance templates. The mechanism is via a template file that is token replaced to provide some specifics about the deployment. See [https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/UserData.md](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/UserData.md) for more information. File needs to be present on the machine running Spinnaker.
 - `consul`: Configuration for Consul.
   - `enabled`: Whether Consul is enabled.
   - `agentEndpoint`: Reachable Consul node endpoint connected to the Consul cluster. Defaults to localhost.
@@ -726,8 +726,8 @@ huaweicloud:
 - `domainName`: (*Required*) The domain name of the cloud.
 - `environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
 - `insecure`: (*Default*: `false`) Disable certificate validation on SSL connections. Needed if certificates are self signed. Default false.
-- `password`: (*Required*) (*Sensitive data- - user will be prompted on standard input) (Sensitive data - user will be prompted on standard input) The password used to access cloud.
-- `project-name`: (*Required*) The name of the project within the cloud.
+- `password`: (*Required*)  The password used to access cloud. Supports encrypted value.
+- `projectName`: (*Required*) The name of the project within the cloud.
 - `regions`: (*Default*: `[]`) (*Required*) The region(s) of the cloud.
 - `username`: (*Required*) The username used to access cloud.
 - `permissions`:
@@ -840,13 +840,13 @@ An account in the Kubernetes provider refers to a single Kubernetes context. In 
 - `cachingPolicies`:
   - `kubernetesKind`:
   - `maxEntriesPerAgent`:
-- `kubeconfigFile`: The path to your kubeconfig file. By default, it will be under the Spinnaker user's home directory in the typical .kube/config location.
+- `kubeconfigFile`: The path to your kubeconfig file. By default, it will be under the Spinnaker user's home directory in the typical .kube/config location. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `kubeconfigContents`: Inline kubeconfig file contents
 - `kubectlPath`: Alternate path inside clouddriver pod of the kubectl binary
 - `kubectlRequestTimeoutSeconds`: Timeout in seconds of kubectl calls
 - `checkPermissionsOnStartup`:  When false, clouddriver will skip the permission checks for all Kubernetes Kinds at startup. This can save a great deal of time during clouddriver startup when you have many Kubernetes accounts configured. This disables the log messages at startup about missing permissions.
 - `liveManifestCalls`: When true, clouddriver will query manifest status during pipeline executions using live data rather than the cache. This eliminates all time spent in the "force cache refresh" task in pipelines, greatly reducing execution time.
-- `oAuthServiceAccount`:
+- `oAuthServiceAccount`: File needs to be present on the machine running Spinnaker.
 - `oAuthScopes`:
 - `namingStrategy`:
 - `skin`:
@@ -921,7 +921,7 @@ oracle:
  - `deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  - `environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  - `fingerprint`: (*Required*) Fingerprint of the public key
- - `privateKeyPassphrase`: Passphrase used for the private key, if it is encrypted
+ - `privateKeyPassphrase`: Passphrase used for the private key, if it is encrypted.Supports encrypted value.
  - `permissions`:
      - `READ`: `[]` A user must have at least one of these roles in order to view this account's cloud resources.
      - `WRITE`: `[]` A user must have at least one of these roles in order to make changes to this account's cloud resources.
@@ -929,7 +929,7 @@ oracle:
      - `CREATE`:
  - `requiredGroupMembership`: `[]` (Deprecated): Configure permissions instead.
  - `region`: (*Required*) An Oracle region (e.g., us-phoenix-1)
- - `sshPrivateKeyFilePath`: (*Required*) Path to the private key in PEM format
+ - `sshPrivateKeyFilePath`: (*Required*) Path to the private key in PEM format. File needs to be present on the machine running Spinnaker. Supports encrypted file.
  - `tenancyId`: (*Required*) Provide the OCID of the Oracle Tenancy to use.
  - `userI`: (*Required*) Provide the OCID of the Oracle User you're authenticating as
 
@@ -1017,12 +1017,12 @@ tencentcloud:
  - `requiredGroupMembership`: `[]` (Deprecated): Configure permissions instead.
  - `regions`: The Tencent CLoud regions this Spinnaker account will manage.
  - `secretId`: (*Required*) The secret id used to access Tencent Cloud.
- - `secretKey`: (*Required*) The secret key used to access Tencent Cloud.
+ - `secretKey`: (*Required*) The secret key used to access Tencent Cloud. Supports encrypted value.
 
 ### Bakery parameters
 
 - `secretId`: (*Required*) The default access key used to communicate with AWS.
-- `secretKey`: (*Required*)  The secret key used to communicate with AWS.
+- `secretKey`: (*Required*)  The secret key used to communicate with AWS. Supports encrypted value.
 - `templateFile`: This is the name of the packer template that will be used to bake images from this base image. The template file must be found in this list [https://github.com/spinnaker/rosco/tree/master/rosco-web/config/packer](https://github.com/spinnaker/rosco/tree/master/rosco-web/config/packer), or supplied as described here: [https://spinnaker.io/setup/bakery/](https://spinnaker.io/setup/bakery/)
 
 #### Bakery base image parameters

--- a/_operator_reference/providers.md
+++ b/_operator_reference/providers.md
@@ -433,7 +433,7 @@ dcos:
 - `insecureSkipTlsVerify`:  If true, disables verification of certificates from the cluster (insecure).
 - `loadBalancer`: Configuration for a DC/OS load balancer
   - `image`: Marathon-lb image to use when creating a load balancer with Spinnaker.
-  - `serviceAccountSecret`: Name of the secret to use for allowing marathon-lb to authenticate with the cluster. Only necessary for clusters with strict or permissive security.
+  - `serviceAccountSecret`: Name of the secret to use for allowing marathon-lb to authenticate with the cluster. Only necessary for clusters with strict or permissive security. Supports encrypted value.
 
 
 ## Docker Registry
@@ -820,7 +820,7 @@ kubernetes:
 
 ### Account parameters
 
-An account in the Kubernetes provider refers to a single Kubernetes context. In Kubernetes, a context is the combination of a Kubernetes cluster and some credentials. If no context is specified, the default context in in your kubeconfig is assumed. You must also provide a set of Docker Registries for each account. Spinnaker will automatically upload that Registry's credentials to the specified Kubernetes cluster allowing you to deploy those images without further configuration.
+An account in the Kubernetes provider refers to a single Kubernetes context. In Kubernetes, a context is the combination of a Kubernetes cluster and some credentials. If no context is specified, the default context in in your `kubeconfig` is assumed. You must also provide a set of Docker Registries for each account. Spinnaker will automatically upload that Registry's credentials to the specified Kubernetes cluster allowing you to deploy those images without further configuration.
 
 - `name`: spinnaker
 - `context`: The kubernetes context to be managed by Spinnaker. See http://kubernetes.io/docs/user-guide/kubeconfig-file/#context for more information. When no context is configured for an account the 'current-context' in your kubeconfig is assumed.
@@ -846,7 +846,7 @@ An account in the Kubernetes provider refers to a single Kubernetes context. In 
 - `kubectlRequestTimeoutSeconds`: Timeout in seconds of kubectl calls
 - `checkPermissionsOnStartup`:  When false, clouddriver will skip the permission checks for all Kubernetes Kinds at startup. This can save a great deal of time during clouddriver startup when you have many Kubernetes accounts configured. This disables the log messages at startup about missing permissions.
 - `liveManifestCalls`: When true, clouddriver will query manifest status during pipeline executions using live data rather than the cache. This eliminates all time spent in the "force cache refresh" task in pipelines, greatly reducing execution time.
-- `oAuthServiceAccount`: File needs to be present on the machine running Spinnaker.
+- `oAuthServiceAccount`: File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `oAuthScopes`:
 - `namingStrategy`:
 - `skin`:

--- a/_operator_reference/pubsub.md
+++ b/_operator_reference/pubsub.md
@@ -40,16 +40,16 @@ pubsub:
 ## Google
 
 - `enabled`: true or false.
-- `subscriptions:
+- `subscriptions`:
   - `name`: subscription name
   - `project`: The name of the GCP project your subscription lives in.
   - `subscriptionName`: The name of the subscription to listen to. This identifier does not include the name of the project, and must already be configured for Spinnaker to work.
-  - `jsonPath`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See https://cloud.google.com/compute/docs/access/service-accounts for more information.
-  - `templatePath`: A path to a jinja template that specifies how artifacts from this pubsub system are interpreted and transformed into Spinnaker artifacts. See spinnaker.io/reference/artifacts for more information.
+  - `jsonPath`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See https://cloud.google.com/compute/docs/access/service-accounts for more information. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+  - `templatePath`: A path to a jinja template that specifies how artifacts from this pubsub system are interpreted and transformed into Spinnaker artifacts. See spinnaker.io/reference/artifacts for more information. File needs to be present on the machine running Spinnaker.
   - `ackDeadlineSeconds`: Time in seconds before an outstanding message is considered unacknowledged and is re-sent. Configurable in your Google Cloud Pubsub subscription. See the docs here`: https://cloud.google.com/pubsub/docs/subscriber
   - `messageFormat`: One of 'GCB', 'GCS', 'GCR', or 'CUSTOM'. This can be used to help Spinnaker translate the contents of the Pub/Sub message into Spinnaker artifacts.
 - `publishers`:
   - `name`: name of publisher
       - `project`:
       - `topicName`:
-      - `jsonPath`:
+      - `jsonPath`: File needs to be present on the machine running Spinnaker. Supports encrypted file.

--- a/_operator_reference/repository.md
+++ b/_operator_reference/repository.md
@@ -34,4 +34,4 @@ repository:
       - `groupId`: The group id in your artifactory to be searched.
       - `repoType`: The package type of repo in your artifactory to be searched.
       - `username`: The username of the artifactory user to authenticate as.
-      - `password`: The password of the artifactory user to authenticate as.
+      - `password`: The password of the artifactory user to authenticate as. Supports encrypted value.

--- a/_operator_reference/security.md
+++ b/_operator_reference/security.md
@@ -115,7 +115,7 @@ oauth2:
 - `enabled`: true or false.
 - `client`:
   - `clientId`: The OAuth client ID you have configured with your OAuth provider.
-  - `clientSecret`: The OAuth client secret you have configured with your OAuth provider.
+  - `clientSecret`: The OAuth client secret you have configured with your OAuth provider. Supports encrypted value.
   - `accessTokenUri`: The access token uri for your OAuth provider.
   - `userAuthorizationUri`: The user authorization uri for your OAuth provider.
   - `clientAuthenticationScheme`: The client authentication scheme for your OAuth provider.
@@ -156,11 +156,11 @@ saml:
 ```
 
 - `enabled`: true or false.
-- `metadataLocal`: The address to your identity provider's metadata XML file. This is a local file.
+- `metadataLocal`: The address to your identity provider's metadata XML file. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `metadataRemote`: The address to your identity provider's metadata XML file. This is a URL.
 - `issuerId`: The identity of the Spinnaker application registered with the SAML provider.
-- `keyStore`: Path to the keystore that contains this server's private key. This key is used to cryptographically sign SAML AuthNRequest objects.
-- `keyStorePassword`: The password used to access the file specified in --keystore
+- `keyStore`: Path to the keystore that contains this server's private key. This key is used to cryptographically sign SAML AuthNRequest objects. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+- `keyStorePassword`: The password used to access the file specified in --keystore. Supports encrypted value.
 - `keyStoreAliasName`: The name of the alias under which this server's private key is stored in the --keystore file.
 - `serviceAddress`: The address of the Gate server that will be accesible by the SAML identity provider. This should be the full URL, including port, e.g. https://gate.org.com:8084/. If deployed behind a load balancer, this would be the load balancer's address.
 - `userAttributeMapping`:

--- a/_operator_reference/security.md
+++ b/_operator_reference/security.md
@@ -327,7 +327,7 @@ uiSecurity:
 ```
 
 - `enabled`: true or false.
-- `sslCertificateFile`: Path to your .crt file.
-- `sslCertificateKeyFile`: Path to your .key file.
-- `sslCertificatePassphrase`: The passphrase needed to unlock your SSL certificate. This will be provided to Apache on startup.
-- `sslCACertificateFile`: Path to the .crt file for the CA that issued your SSL certificate. This is only needed for localgitdeployments that serve the UI using webpack dev server.
+- `sslCertificateFile`: Path to your .crt file. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+- `sslCertificateKeyFile`: Path to your .key file. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+- `sslCertificatePassphrase`: The passphrase needed to unlock your SSL certificate. This will be provided to Apache on startup. Supports encrypted value.
+- `sslCACertificateFile`: Path to the .crt file for the CA that issued your SSL certificate. This is only needed for localgitdeployments that serve the UI using webpack dev server. File needs to be present on the machine running Spinnaker. Supports encrypted file.

--- a/_operator_reference/security.md
+++ b/_operator_reference/security.md
@@ -56,12 +56,12 @@ apiSecurity:
 
 - `enabled`: true or false.
 - `keyAlias`: Name of your keystore entry as generated with your keytool.
-- `keyStore`: Path to the keystore holding your security certificates.
+- `keyStore`: Path to the keystore holding your security certificates. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `keyStoreType`: The type of your keystore. Examples include JKS, and PKCS12.
-- `keyStorePassword`: The password to unlock your keystore. Due to a limitation in Tomcat, this must match your key's password in the keystore.
-- `trustStore`: Path to the truststore holding your trusted certificates.
+- `keyStorePassword`: The password to unlock your keystore. Due to a limitation in Tomcat, this must match your key's password in the keystore. Supports encrypted value.
+- `trustStore`: Path to the truststore holding your trusted certificates. File needs to be present on the machine running Spinnaker. Supports encrypted file.
 - `trustStoreType`: The type of your truststore. Examples include JKS, and PKCS12.
-- `trustStorePassword`: The password to unlock your truststore.
+- `trustStorePassword`: The password to unlock your truststore. Supports encrypted value.
 - `clientAuth`: Declare `WANT` when client auth is wanted but not mandatory or `NEED` when client auth is mandatory.
 
 
@@ -278,13 +278,13 @@ groupMembership:
 - `service`: One of `EXTERNAL`, `FILE`, `GOOGLE`, `GITHUB`, `LDAP`
 - `google`:
   - `roleProviderType`: `GOOGLE`
-  - `credentialPath`: A path to a valid json service account that can authenticate against the Google role provider.
+  - `credentialPath`: A path to a valid json service account that can authenticate against the Google role provider. File needs to be present on the machine running Spinnaker. Supports encrypted file.
   - `adminUsername`: Your role provider's admin username e.g. admin@myorg.net
   - `domain`: The domain your role provider is configured for e.g. myorg.net.
 - `github`:
   - `roleProviderType`: `GITHUB`
   - `baseUrl`: Used if using GitHub enterprise some other non github.com GitHub installation.
-  - `accessToken`: A personal access token of an account with access to your organization's GitHub Teams structure.
+  - `accessToken`: A personal access token of an account with access to your organization's GitHub Teams structure. Supports encrypted value.
   - `organization`: The GitHub organization under which to query for GitHub Teams.
 - `file`:
   - `roleProviderType`: `FILE`
@@ -293,7 +293,7 @@ groupMembership:
   - `roleProviderType`: `LDAP`
   - `url`: ldap:// or ldaps:// URL of the LDAP server
   - `managerDn`: The manager user's distinguished name (principal) to use for querying ldap groups.
-  - `managerPassword`: The manager user's password to use for querying ldap groups.
+  - `managerPassword`: The manager user's password to use for querying ldap groups. Supports encrypted value.
   - `userDnPattern`: The pattern for finding a user's DN using simple pattern matching. For example, if your LDAP server has the URL ldap://mysite.com/dc=spinnaker,dc=org, and you have the pattern 'uid={0},ou=members', 'me' will map to a DN uid=me,ou=members,dc=spinnaker,dc=org. If no match is found, will try to find the user using --user-search-filter, if set.
   - `userSearchBase`: The part of the directory tree under which user searches should be performed. If --user-search-base isn't supplied, the search will be performed from the root.
   - `groupSearchBase`: The part of the directory tree under which group searches should be performed.

--- a/_operator_reference/webhook.md
+++ b/_operator_reference/webhook.md
@@ -22,5 +22,5 @@ webhook:
 
 - `trust`:
   - `enabled`: false
-  - `trustStore`: The path to a key store in JKS format containing certification authorities that should be trusted by webhook stages. File needs to be present on the machine running Spinnaker. Supports encrypted file.
+  - `trustStore`: The path to a key store in JKS format containing certification authorities that should be trusted by webhook stages. File needs to be present on the machine running Spinnaker.
   - `trustStorePassword`: The password for the supplied trustStore.

--- a/_operator_reference/webhook.md
+++ b/_operator_reference/webhook.md
@@ -22,5 +22,5 @@ webhook:
 
 - `trust`:
   - `enabled`: false
-  - `trustStore`: The path to a key store in JKS format containing certification authorities that should be trusted by webhook stages.
+  - `trustStore`: The path to a key store in JKS format containing certification authorities that should be trusted by webhook stages. File needs to be present on the machine running Spinnaker. Supports encrypted file.
   - `trustStorePassword`: The password for the supplied trustStore.


### PR DESCRIPTION
Indicate which parameters support encrypted values with "Supports encrypted value."
Indicate which file parameters require a local file with "File needs to be present on the machine running Spinnaker." (pulled from the Java source code)
Indicate which file parameters support an encrypted file with "Supports encrypted file."