### PR TITLE
docs(dynamic-accounts): initial creation

### DIFF
--- a/_spinnaker_install_admin_guides/dynamic_accounts.md
+++ b/_spinnaker_install_admin_guides/dynamic_accounts.md
@@ -1,0 +1,139 @@
+---
+layout: post
+title: Dynamic Kubernetes Accounts With Vault
+order: 32
+---
+
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+# Dynamic Kubernetes Accounts with Vault
+
+If you will be adding, deleting, or modifying kubernetes deployment targets on a regular basis you may find that re-deploying clouddriver to pull in new
+account configuration is impactful to your teams. Spinnaker's External Account Configuration feature will allow you to manage account configuration 
+externally from Spinnaker and then re-read that configuration without requiring a re-deployment of clouddriver.
+
+External Account Configuration is only supported for kubernetes and cloud foundry provider accounts. This document describes how this works with kubernetes acccounts.
+
+
+## Prerequisites
+This document assumes the following:
+- Your Spinnaker cluster is up and running
+- You have a Vault instance accessible from your Spinnaker cluster
+- You have a valid kubeconfig for the target Kubernetes cluster
+  
+
+## Background
+
+External Account Configuration uses Spring Cloud Config Server to allow portions of clouddriver's configuration from an external source. Details on the implementation and
+limitations can be found [here](https://www.spinnaker.io/setup/configuration/#external-account-configuration).
+
+The steps involved in setting up Dynamic Kubernetes Accounts include:
+- Create a secret in Vault of type json that stores the entire contents of the kubernetes account portion of the clouddriver configuration
+- Update (or create) the `spinnakerconfig.yml` file to enable Spring Cloud Config Server and to connect it to Vault
+- Re-deploy Spinnaker
+
+
+## Create secret in vault
+
+The secret in vault will contain the accounts section that was previously in your halyard or operator configuration. Note that you will still need to leave the configuration in halyard or operator for the kubernetes account where spinnaker is deployed. Clouddriver *replaces* all of its account information with what it finds in the vault token. You will need to put the configuration for the spinnaker cluster if you want that cluster to be used as a deployment target for clouddriver. 
+
+The kubeconfig file for each cluster will be stored inline as a single-line string in the kubeconfigContents element of the json. To convert a kubeconfig file to a string, you can use a sed command:
+  sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' kubeconfig.yml
+
+
+Create a secret in vault of type json with contents specific for your accounts:
+
+  {
+    "kubernetes": {
+      "accounts": [
+        {
+          "cacheThreads": 1,
+          "cachingPolicies": [],
+          "configureImagePullSecrets": true,
+          "customResources": [],
+          "dockerRegistries": [],
+          "kinds": [],
+          "kubeconfigContents": "<YOUR SINGLE LINE KUBECONFIG CONTENTS>",
+          "name": "<YOUR NAME FOR THE ACCOUNT>",
+          "namespaces": [],
+          "oAuthScopes": [],
+          "omitKinds": [],
+          "omitNamespaces": [],
+          "onlySpinnakerManaged": true,
+          "permissions": {},
+          "providerVersion": "V2",
+          "requiredGroupMembership": []
+        },
+       {
+          "cacheThreads": 1,
+          "cachingPolicies": [],
+          "configureImagePullSecrets": true,
+          "customResources": [],
+          "dockerRegistries": [],
+          "kinds": [],
+          "kubeconfigContents": "<YOUR NEXT SINGLE LINE KUBECONFIG CONTENTS>",
+          "name": "<YOUR NAME FOR THE NEXT ACCOUNT>",
+          "namespaces": [],
+          "oAuthScopes": [],
+          "omitKinds": [],
+          "omitNamespaces": [],
+          "onlySpinnakerManaged": true,
+          "permissions": {},
+          "providerVersion": "V2",
+          "requiredGroupMembership": []
+        },
+      ]
+    }
+  }
+
+
+
+## Update spinnakerconfig.yml
+
+Update the `spinnakerconfig.yml` file with the following contents. This file will normally be in `.hal/default/profiles`. Create it if it does not exist. 
+    spring:
+      profiles:
+        include: vault
+      cloud:
+        config:
+          server:
+            vault:
+              host: <YOUR VAULT IP OR HOSNAME>
+              port: 8200
+              backend: <YOUR VAULT SECRET ENGINE>
+              kvVersion: 2
+              scheme: http
+              default-key: <YOUR VAULT SECRET NAME>
+              token: <YOUR VAULT ACCESS TOKEN>
+
+If your secret is at spinnaker/clouddriver then your backend will be spinnaker and your default-key will be clouddriver. 
+
+Methods for accessing vault other than by token are available. See the [Spring Cloud Config Server documentation](https://cloud.spring.io/spring-cloud-static/spring-cloud-config/2.2.1.RELEASE/reference/html/#vault-backend) for more information. 
+
+
+## Re-deploy Spinnaker
+
+After making the changes to `spinnakerconfig.yml` you'll need to re-deploy Spinnaker to apply the changes. Do a `hal deploy apply` and wait for all pods to be running and ready.
+
+
+## Check Spinnake for New Accounts
+
+When all of the pods are running and ready, do a hard refresh of the Spinnaker web interface. The accounts you added in the vault secret should now be available in the web interface for use.
+
+
+## Troubleshooting
+
+If the configuration in the spinnakerconfig.yml is incorrect, clouddriver may not start. Because External Account Configuration is also available for the echo and igor services, you may see issues with those pods as well. Check the clouddriver logs for errors related to the vault profile. Use the `kubectl logs <clouddriver pod name>` command to view the logs.
+
+If External Account Configuration is working properly, you should see messages similar to the following in the clouddriver log if the accounts were loaded and there were no changes:
+  2020-04-23 13:49:29.921  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : The following profiles are active: composite,vault,local
+  2020-04-23 13:49:29.951  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : Started application in 1.55 seconds (JVM running for 63660.417)
+  2020-04-23 13:49:30.180  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : No changes detected to V2 Kubernetes accounts. Skipping caching agent synchronization.
+
+If a change to an account is made, you should see messages similar to this:
+  2020-04-23 14:07:00.905  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : The following profiles are active: composite,vault,local
+  2020-04-23 14:07:00.921  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : Started application in 1.602 seconds (JVM running for 64711.387)
+  2020-04-23 14:07:01.178  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : Synchronizing 1 caching agents for V2 Kubernetes accounts.
+  2020-04-23 14:07:01.181  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : Adding 3 agents for account newaccount

--- a/_spinnaker_install_admin_guides/dynamic_accounts.md
+++ b/_spinnaker_install_admin_guides/dynamic_accounts.md
@@ -44,7 +44,7 @@ The kubeconfig file for each cluster will be stored inline as a single-line stri
 
 
 Create a secret in vault of type json with contents specific for your accounts:
-
+```
   {
     "kubernetes": {
       "accounts": [
@@ -87,12 +87,13 @@ Create a secret in vault of type json with contents specific for your accounts:
       ]
     }
   }
-
+```
 
 
 ## Update spinnakerconfig.yml
 
 Update the `spinnakerconfig.yml` file with the following contents. This file will normally be in `.hal/default/profiles`. Create it if it does not exist. 
+```
     spring:
       profiles:
         include: vault
@@ -107,7 +108,7 @@ Update the `spinnakerconfig.yml` file with the following contents. This file wil
               scheme: http
               default-key: <YOUR VAULT SECRET NAME>
               token: <YOUR VAULT ACCESS TOKEN>
-
+```
 If your secret is at spinnaker/clouddriver then your backend will be spinnaker and your default-key will be clouddriver. 
 
 Methods for accessing vault other than by token are available. See the [Spring Cloud Config Server documentation](https://cloud.spring.io/spring-cloud-static/spring-cloud-config/2.2.1.RELEASE/reference/html/#vault-backend) for more information. 
@@ -118,9 +119,9 @@ Methods for accessing vault other than by token are available. See the [Spring C
 After making the changes to `spinnakerconfig.yml` you'll need to re-deploy Spinnaker to apply the changes. Do a `hal deploy apply` and wait for all pods to be running and ready.
 
 
-## Check Spinnake for New Accounts
+## Check Spinnaker for New Accounts
 
-When all of the pods are running and ready, do a hard refresh of the Spinnaker web interface. The accounts you added in the vault secret should now be available in the web interface for use.
+When all of the pods are running and ready do a hard refresh of the Spinnaker web interface. The accounts you added in the vault secret should now be available in the web interface for use.
 
 
 ## Troubleshooting
@@ -128,12 +129,15 @@ When all of the pods are running and ready, do a hard refresh of the Spinnaker w
 If the configuration in the spinnakerconfig.yml is incorrect, clouddriver may not start. Because External Account Configuration is also available for the echo and igor services, you may see issues with those pods as well. Check the clouddriver logs for errors related to the vault profile. Use the `kubectl logs <clouddriver pod name>` command to view the logs.
 
 If External Account Configuration is working properly, you should see messages similar to the following in the clouddriver log if the accounts were loaded and there were no changes:
+```
   2020-04-23 13:49:29.921  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : The following profiles are active: composite,vault,local
   2020-04-23 13:49:29.951  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : Started application in 1.55 seconds (JVM running for 63660.417)
   2020-04-23 13:49:30.180  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : No changes detected to V2 Kubernetes accounts. Skipping caching agent synchronization.
-
+```
 If a change to an account is made, you should see messages similar to this:
+```
   2020-04-23 14:07:00.905  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : The following profiles are active: composite,vault,local
   2020-04-23 14:07:00.921  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : Started application in 1.602 seconds (JVM running for 64711.387)
   2020-04-23 14:07:01.178  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : Synchronizing 1 caching agents for V2 Kubernetes accounts.
   2020-04-23 14:07:01.181  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : Adding 3 agents for account newaccount
+```

--- a/_spinnaker_install_admin_guides/dynamic_accounts.md
+++ b/_spinnaker_install_admin_guides/dynamic_accounts.md
@@ -10,134 +10,141 @@ order: 32
 
 # Dynamic Kubernetes Accounts with Vault
 
-If you will be adding, deleting, or modifying kubernetes deployment targets on a regular basis you may find that re-deploying clouddriver to pull in new
-account configuration is impactful to your teams. Spinnaker's External Account Configuration feature will allow you to manage account configuration 
-externally from Spinnaker and then re-read that configuration without requiring a re-deployment of clouddriver.
+If you be add, delete, or modify Kubernetes deployment targets on a regular basis, you may find that redeploying Clouddriver to pull in new
+account configuration impacts your teams. Spinnaker's [External Account Configuration](https://www.spinnaker.io/setup/configuration/#external-account-configuration) feature allows you to manage account configuration
+externally from Spinnaker and then read that configuration change without requiring a redeployment of Clouddriver.
 
-External Account Configuration is only supported for kubernetes and cloud foundry provider accounts. This document describes how this works with kubernetes acccounts.
+External Account Configuration is only supported for Kubernetes and cloud foundry provider accounts. This document describes how this works with Kubernetes acccounts.
 
 
 ## Prerequisites
+
 This document assumes the following:
-- Your Spinnaker cluster is up and running
-- You have a Vault instance accessible from your Spinnaker cluster
-- You have a valid kubeconfig for the target Kubernetes cluster
-  
+
+- You have a running Spinnaker cluster.
+- You have a Vault instance accessible from your Spinnaker cluster.
+- You have a valid `kubeconfig` for the target Kubernetes cluster.
+
 
 ## Background
 
-External Account Configuration uses Spring Cloud Config Server to allow portions of clouddriver's configuration from an external source. Details on the implementation and
-limitations can be found [here](https://www.spinnaker.io/setup/configuration/#external-account-configuration).
+External Account Configuration uses Spring Cloud Config Server to
+allow portions of Clouddriver's configuration to be from an external
+source. See [Enabling external configuration](https://www.spinnaker.io/setup/configuration/#enabling-external-configuration) for details on the implementation and its limitations.
 
-The steps involved in setting up Dynamic Kubernetes Accounts include:
-- Create a secret in Vault of type json that stores the entire contents of the kubernetes account portion of the clouddriver configuration
-- Update (or create) the `spinnakerconfig.yml` file to enable Spring Cloud Config Server and to connect it to Vault
-- Re-deploy Spinnaker
+The steps involved in setting up Dynamic Kubernetes Accounts are:
 
+1. Create a JSON type secret in Vault. This secret stores the entire contents of the Kubernetes account portion of the Clouddriver configuration.
+1. Create or update the `spinnakerconfig.yml` file to enable Spring Cloud Config Server and to connect it to Vault.
+1. Redeploy Spinnaker.
 
-## Create secret in vault
+## Create the Secret in Vault
 
-The secret in vault will contain the accounts section that was previously in your halyard or operator configuration. Note that you will still need to leave the configuration in halyard or operator for the kubernetes account where spinnaker is deployed. Clouddriver *replaces* all of its account information with what it finds in the vault token. You will need to put the configuration for the spinnaker cluster if you want that cluster to be used as a deployment target for clouddriver. 
+The secret in Vault contains the `accounts` section that was previously in your Halyard or Operator configuration. Note that you still need to leave the configuration in Halyard or Operator for the Kubernetes account where Spinnaker is deployed. Clouddriver *replaces* all of its account information with what it finds in the Vault token. You need to add the configuration for the Spinnaker cluster if you want to use that cluster a deployment target for Clouddriver.
 
-The kubeconfig file for each cluster will be stored inline as a single-line string in the kubeconfigContents element of the json. To convert a kubeconfig file to a string, you can use a sed command:
-  sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' kubeconfig.yml
+The `kubeconfig` file for each cluster is stored inline as a single line string in the `kubeconfigContents` element of the JSON. You can use a `sed` command to convert a `kubeconfig` file to a string:
 
-
-Create a secret in vault of type json with contents specific for your accounts:
-```
-  {
-    "kubernetes": {
-      "accounts": [
-        {
-          "cacheThreads": 1,
-          "cachingPolicies": [],
-          "configureImagePullSecrets": true,
-          "customResources": [],
-          "dockerRegistries": [],
-          "kinds": [],
-          "kubeconfigContents": "<YOUR SINGLE LINE KUBECONFIG CONTENTS>",
-          "name": "<YOUR NAME FOR THE ACCOUNT>",
-          "namespaces": [],
-          "oAuthScopes": [],
-          "omitKinds": [],
-          "omitNamespaces": [],
-          "onlySpinnakerManaged": true,
-          "permissions": {},
-          "providerVersion": "V2",
-          "requiredGroupMembership": []
-        },
-       {
-          "cacheThreads": 1,
-          "cachingPolicies": [],
-          "configureImagePullSecrets": true,
-          "customResources": [],
-          "dockerRegistries": [],
-          "kinds": [],
-          "kubeconfigContents": "<YOUR NEXT SINGLE LINE KUBECONFIG CONTENTS>",
-          "name": "<YOUR NAME FOR THE NEXT ACCOUNT>",
-          "namespaces": [],
-          "oAuthScopes": [],
-          "omitKinds": [],
-          "omitNamespaces": [],
-          "onlySpinnakerManaged": true,
-          "permissions": {},
-          "providerVersion": "V2",
-          "requiredGroupMembership": []
-        },
-      ]
-    }
-  }
+```bash
+sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' kubeconfig.yml
 ```
 
+Create a secret in Vault of type JSON with contents specific for your accounts:
+
+```json
+{
+"kubernetes": {
+  "accounts": [
+    {
+      "cacheThreads": 1,
+      "cachingPolicies": [],
+      "configureImagePullSecrets": true,
+      "customResources": [],
+      "dockerRegistries": [],
+      "kinds": [],
+      "kubeconfigContents": "<YOUR SINGLE LINE KUBECONFIG CONTENTS>",
+      "name": "<YOUR NAME FOR THE ACCOUNT>",
+      "namespaces": [],
+      "oAuthScopes": [],
+      "omitKinds": [],
+      "omitNamespaces": [],
+      "onlySpinnakerManaged": true,
+      "permissions": {},
+      "providerVersion": "V2",
+      "requiredGroupMembership": []
+    },
+   {
+      "cacheThreads": 1,
+      "cachingPolicies": [],
+      "configureImagePullSecrets": true,
+      "customResources": [],
+      "dockerRegistries": [],
+      "kinds": [],
+      "kubeconfigContents": "<YOUR NEXT SINGLE LINE KUBECONFIG CONTENTS>",
+      "name": "<YOUR NAME FOR THE NEXT ACCOUNT>",
+      "namespaces": [],
+      "oAuthScopes": [],
+      "omitKinds": [],
+      "omitNamespaces": [],
+      "onlySpinnakerManaged": true,
+      "permissions": {},
+      "providerVersion": "V2",
+      "requiredGroupMembership": []
+    },
+  ]
+}
+}
+```
 
 ## Update spinnakerconfig.yml
 
-Update the `spinnakerconfig.yml` file with the following contents. This file will normally be in `.hal/default/profiles`. Create it if it does not exist. 
+Create or update the `spinnakerconfig.yml` file, which is normally in `.hal/default/profiles`, with the following content:
+
+```yaml
+spring:
+  profiles:
+    include: vault
+  cloud:
+    config:
+      server:
+        vault:
+          host: <YOUR VAULT IP OR HOSNAME>
+          port: 8200
+          backend: <YOUR VAULT SECRET ENGINE>
+          kvVersion: 2
+          scheme: http
+          default-key: <YOUR VAULT SECRET NAME>
+          token: <YOUR VAULT ACCESS TOKEN>
 ```
-    spring:
-      profiles:
-        include: vault
-      cloud:
-        config:
-          server:
-            vault:
-              host: <YOUR VAULT IP OR HOSNAME>
-              port: 8200
-              backend: <YOUR VAULT SECRET ENGINE>
-              kvVersion: 2
-              scheme: http
-              default-key: <YOUR VAULT SECRET NAME>
-              token: <YOUR VAULT ACCESS TOKEN>
-```
-If your secret is at spinnaker/clouddriver then your backend will be spinnaker and your default-key will be clouddriver. 
 
-Methods for accessing vault other than by token are available. See the [Spring Cloud Config Server documentation](https://cloud.spring.io/spring-cloud-static/spring-cloud-config/2.2.1.RELEASE/reference/html/#vault-backend) for more information. 
+If your secret is at `spinnaker/clouddriver`, then your backend will be `spinnaker` and your `default-key` will be `clouddriver`.
 
+Methods for accessing Vault other than by token are available. See the [Spring Cloud Config Server documentation](https://cloud.spring.io/spring-cloud-static/spring-cloud-config/2.2.1.RELEASE/reference/html/#vault-backend) for more information.
 
-## Re-deploy Spinnaker
+## Redeploy Spinnaker
 
-After making the changes to `spinnakerconfig.yml` you'll need to re-deploy Spinnaker to apply the changes. Do a `hal deploy apply` and wait for all pods to be running and ready.
-
+You need to redeploy Spinnaker after making the changes to `spinnakerconfig.yml`. Do a `hal deploy apply` and wait for all pods to be running and ready.
 
 ## Check Spinnaker for New Accounts
 
-When all of the pods are running and ready do a hard refresh of the Spinnaker web interface. The accounts you added in the vault secret should now be available in the web interface for use.
-
+When all of the pods are running and ready, do a hard refresh of the Spinnaker web interface. The accounts you added in the Vault secret should now be available in the web interface for you to use.
 
 ## Troubleshooting
 
-If the configuration in the spinnakerconfig.yml is incorrect, clouddriver may not start. Because External Account Configuration is also available for the echo and igor services, you may see issues with those pods as well. Check the clouddriver logs for errors related to the vault profile. Use the `kubectl logs <clouddriver pod name>` command to view the logs.
+If the configuration in the `spinnakerconfig.yml` is incorrect, Clouddriver may not start. Because External Account Configuration is also available for the Echo and Igor services, you may see issues with those pods as well. Check the Clouddriver logs for errors related to the Vault profile. Use the `kubectl logs <clouddriver pod name>` command to view the logs.
 
-If External Account Configuration is working properly, you should see messages similar to the following in the clouddriver log if the accounts were loaded and there were no changes:
+If External Account Configuration is working properly, you should see messages similar to the following in the Clouddriver log if the accounts were loaded and there were no changes:
+
+```bash
+2020-04-23 13:49:29.921  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : The following profiles are active: composite,vault,local
+2020-04-23 13:49:29.951  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : Started application in 1.55 seconds (JVM running for 63660.417)
+2020-04-23 13:49:30.180  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : No changes detected to V2 Kubernetes accounts. Skipping caching agent synchronization.
 ```
-  2020-04-23 13:49:29.921  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : The following profiles are active: composite,vault,local
-  2020-04-23 13:49:29.951  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : Started application in 1.55 seconds (JVM running for 63660.417)
-  2020-04-23 13:49:30.180  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : No changes detected to V2 Kubernetes accounts. Skipping caching agent synchronization.
-```
+
 If a change to an account is made, you should see messages similar to this:
-```
-  2020-04-23 14:07:00.905  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : The following profiles are active: composite,vault,local
-  2020-04-23 14:07:00.921  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : Started application in 1.602 seconds (JVM running for 64711.387)
-  2020-04-23 14:07:01.178  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : Synchronizing 1 caching agents for V2 Kubernetes accounts.
-  2020-04-23 14:07:01.181  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : Adding 3 agents for account newaccount
+
+```bash
+2020-04-23 14:07:00.905  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : The following profiles are active: composite,vault,local
+2020-04-23 14:07:00.921  INFO 1 --- [reshScheduler-0] o.s.boot.SpringApplication               : Started application in 1.602 seconds (JVM running for 64711.387)
+2020-04-23 14:07:01.178  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : Synchronizing 1 caching agents for V2 Kubernetes accounts.
+2020-04-23 14:07:01.181  INFO 1 --- [reshScheduler-0] k.v.c.KubernetesV2ProviderSynchronizable : Adding 3 agents for account newaccount
 ```


### PR DESCRIPTION
This document explains how to use the OSS external configuration feature with vault to dynamically load kubernetes accounts. It takes the information that is in the OSS docs and makes it usable. 