### PR TITLE
docs(chore): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @armory/docs-team


### PR DESCRIPTION
Add .github folder with CODEOWNERS file. docs-team will be auto-assigned to each PR.