### PR TITLE
docs(Architecture.md): Changed Terrafomer typo to Terraformer

### DIFF
--- a/_spinnaker_install_admin_guides/architecture.md
+++ b/_spinnaker_install_admin_guides/architecture.md
@@ -59,5 +59,5 @@ Dinghy is the Armory-specific microservice used to manage Pipelines as Code.  It
 * Automatically synchronizing pipeline definitions from an external Github or BitBucket repository to Armory Spinnaker.
 * Creating a library of pipeline modules (components) that can be templatized and used in Dinghy-managed pipeline definitions.
 
-### Terrafomer
+### Terraformer
 Terraformer is the Armory-specific microservice used to run Terraform scripts within a Spinnaker pipeline.


### PR DESCRIPTION
Running my first PR against Armory Docs to test out and document the process in thorough detail. There was a mini typo in Architecture.md. 