### PR TITLE
docs(release_notes): MySQL Table Renaming Breaking Change

### DIFF
--- a/_release_notes/armoryspinnaker_v2.19.4.md
+++ b/_release_notes/armoryspinnaker_v2.19.4.md
@@ -29,6 +29,8 @@ This version includes an upgrade to the Spring Boot dependency. This requires yo
 ### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
 As a part of the upgrade from 2.18.x to 2.19.x, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
 
+This issue only occurs if you upgrade to 2.19.x and then downgrade.
+
 ### Service Accounts using Fiat
 
 There is an issue creating or updating service accounts. This causes the pipeline permissions feature to not work.  

--- a/_release_notes/armoryspinnaker_v2.19.4.md
+++ b/_release_notes/armoryspinnaker_v2.19.4.md
@@ -24,6 +24,8 @@ Armory Spinnaker 2.19.x requires Armory Halyard 1.8.3 or later.
 ### HTTP sessions for Gate
 This version includes an upgrade to the Spring Boot dependency. This requires you to flush all the Gate sessions for your Spinnaker deployment. For more information, see [Flushing Gate Sessions](https://kb.armory.io/admin/flush-gate-sessions/).
 
+### Upgrading from 2.18.x with MySQL used for Front50 will Rename Table plugin_artifacts
+As a part of upgrading from 2.18.x to 2.19.x the table **plugin_artifacts** is renamed to **plugin_info**.  Please be advised that attempting to downgrade from 2.19.x to 2.18.x will not revert naming of the table, and it will continue to be named as **plugin_info**, preventing access to the table.  
 
 ## Known Issues
 

--- a/_release_notes/armoryspinnaker_v2.19.4.md
+++ b/_release_notes/armoryspinnaker_v2.19.4.md
@@ -24,10 +24,10 @@ Armory Spinnaker 2.19.x requires Armory Halyard 1.8.3 or later.
 ### HTTP sessions for Gate
 This version includes an upgrade to the Spring Boot dependency. This requires you to flush all the Gate sessions for your Spinnaker deployment. For more information, see [Flushing Gate Sessions](https://kb.armory.io/admin/flush-gate-sessions/).
 
-### Upgrading from 2.18.x with MySQL used for Front50 will Rename Table plugin_artifacts
-As a part of upgrading from 2.18.x to 2.19.x the table **plugin_artifacts** is renamed to **plugin_info**.  Please be advised that attempting to downgrade from 2.19.x to 2.18.x will not revert naming of the table, and it will continue to be named as **plugin_info**, preventing access to the table.  
-
 ## Known Issues
+
+### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
+As a part of the upgrade from 2.18.x to 2.19.x, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
 
 ### Service Accounts using Fiat
 

--- a/_release_notes/armoryspinnaker_v2.19.5.md
+++ b/_release_notes/armoryspinnaker_v2.19.5.md
@@ -35,6 +35,9 @@ The Kubernetes V1 provider will be removed in Spinnaker 1.21. Please see the [RF
 
 Breaking change: Kubernetes accounts with an unspecified providerVersion will now default to V2. Update your Halconfig to specify `providerVersion: v1` for any Kubernetes accounts you are currently using with the V1 provider.
 
+### Upgrading from 2.18.x with MySQL used for Front50 will Rename Table plugin_artifacts
+As a part of upgrading from 2.18.x to 2.19.x the table **plugin_artifacts** is renamed to **plugin_info**.  Please be advised that attempting to downgrade from 2.19.x to 2.18.x will not revert naming of the table, and it will continue to be named as **plugin_info**, preventing access to the table.  
+
 
 ## Known Issues
 

--- a/_release_notes/armoryspinnaker_v2.19.5.md
+++ b/_release_notes/armoryspinnaker_v2.19.5.md
@@ -41,6 +41,8 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 ### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
 As a part of the upgrade from 2.18.x to 2.19.x, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
 
+This issue only occurs if you upgrade to 2.19.x and then downgrade.
+
 ### Service Accounts using Fiat
 
 There is an issue creating or updating service accounts. This causes the pipeline permissions feature to not work.  

--- a/_release_notes/armoryspinnaker_v2.19.5.md
+++ b/_release_notes/armoryspinnaker_v2.19.5.md
@@ -35,11 +35,11 @@ The Kubernetes V1 provider will be removed in Spinnaker 1.21. Please see the [RF
 
 Breaking change: Kubernetes accounts with an unspecified providerVersion will now default to V2. Update your Halconfig to specify `providerVersion: v1` for any Kubernetes accounts you are currently using with the V1 provider.
 
-### Upgrading from 2.18.x with MySQL used for Front50 will Rename Table plugin_artifacts
-As a part of upgrading from 2.18.x to 2.19.x the table **plugin_artifacts** is renamed to **plugin_info**.  Please be advised that attempting to downgrade from 2.19.x to 2.18.x will not revert naming of the table, and it will continue to be named as **plugin_info**, preventing access to the table.  
-
 
 ## Known Issues
+
+### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
+As a part of the upgrade from 2.18.x to 2.19.x, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
 
 ### Service Accounts using Fiat
 

--- a/_release_notes/armoryspinnaker_v2.19.6.md
+++ b/_release_notes/armoryspinnaker_v2.19.6.md
@@ -27,10 +27,10 @@ The Kubernetes V1 provider will be removed in Spinnaker 1.21. Please see the [RF
 
 Breaking change: Kubernetes accounts with an unspecified providerVersion will now default to V2. Update your Halconfig to specify `providerVersion: v1` for any Kubernetes accounts you are currently using with the V1 provider.
 
-### Upgrading from 2.18.x with MySQL used for Front50 will Rename Table plugin_artifacts
-As a part of upgrading from 2.18.x to 2.19.x the table **plugin_artifacts** is renamed to **plugin_info**.  Please be advised that attempting to downgrade from 2.19.x to 2.18.x will not revert naming of the table, and it will continue to be named as **plugin_info**, preventing access to the table.  
-
 ## Known Issues
+
+### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
+As a part of the upgrade from 2.18.x to 2.19.x, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
 
 ### Service Accounts using Fiat
 

--- a/_release_notes/armoryspinnaker_v2.19.6.md
+++ b/_release_notes/armoryspinnaker_v2.19.6.md
@@ -27,6 +27,9 @@ The Kubernetes V1 provider will be removed in Spinnaker 1.21. Please see the [RF
 
 Breaking change: Kubernetes accounts with an unspecified providerVersion will now default to V2. Update your Halconfig to specify `providerVersion: v1` for any Kubernetes accounts you are currently using with the V1 provider.
 
+### Upgrading from 2.18.x with MySQL used for Front50 will Rename Table plugin_artifacts
+As a part of upgrading from 2.18.x to 2.19.x the table **plugin_artifacts** is renamed to **plugin_info**.  Please be advised that attempting to downgrade from 2.19.x to 2.18.x will not revert naming of the table, and it will continue to be named as **plugin_info**, preventing access to the table.  
+
 ## Known Issues
 
 ### Service Accounts using Fiat

--- a/_release_notes/armoryspinnaker_v2.19.6.md
+++ b/_release_notes/armoryspinnaker_v2.19.6.md
@@ -32,6 +32,8 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 ### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
 As a part of the upgrade from 2.18.x to 2.19.x, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
 
+This issue only occurs if you upgrade to 2.19.x and then downgrade.
+
 ### Service Accounts using Fiat
 
 There is an issue creating or updating service accounts. This causes the pipeline permissions feature to not work.  

--- a/_release_notes/armoryspinnaker_v2.19.7.md
+++ b/_release_notes/armoryspinnaker_v2.19.7.md
@@ -36,6 +36,7 @@ There is a known issue with the Plugins framework in Armory Spinnaker 2.17.7. If
 ### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
 As a part of the upgrade from 2.18.x to 2.19.x, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
 
+This issue only occurs if you upgrade to 2.19.x and then downgrade.
 
 ## Highlighted Updates
 

--- a/_release_notes/armoryspinnaker_v2.19.7.md
+++ b/_release_notes/armoryspinnaker_v2.19.7.md
@@ -27,6 +27,9 @@ The Kubernetes V1 provider will be removed in Spinnaker 1.21. Please see the [RF
 
 Breaking change: Kubernetes accounts with an unspecified providerVersion will now default to V2. Update your Halconfig to specify `providerVersion: v1` for any Kubernetes accounts you are currently using with the V1 provider.
 
+### Upgrading from 2.18.x with MySQL used for Front50 will Rename Table plugin_artifacts
+As a part of upgrading from 2.18.x to 2.19.x the table **plugin_artifacts** is renamed to **plugin_info**.  Please be advised that attempting to downgrade from 2.19.x to 2.18.x will not revert naming of the table, and it will continue to be named as **plugin_info**, preventing access to the table.  
+
 ## Known Issues
 
 ### Plugins

--- a/_release_notes/armoryspinnaker_v2.19.7.md
+++ b/_release_notes/armoryspinnaker_v2.19.7.md
@@ -27,14 +27,15 @@ The Kubernetes V1 provider will be removed in Spinnaker 1.21. Please see the [RF
 
 Breaking change: Kubernetes accounts with an unspecified providerVersion will now default to V2. Update your Halconfig to specify `providerVersion: v1` for any Kubernetes accounts you are currently using with the V1 provider.
 
-### Upgrading from 2.18.x with MySQL used for Front50 will Rename Table plugin_artifacts
-As a part of upgrading from 2.18.x to 2.19.x the table **plugin_artifacts** is renamed to **plugin_info**.  Please be advised that attempting to downgrade from 2.19.x to 2.18.x will not revert naming of the table, and it will continue to be named as **plugin_info**, preventing access to the table.  
-
 ## Known Issues
 
 ### Plugins
 
 There is a known issue with the Plugins framework in Armory Spinnaker 2.17.7. If you want to build or use plugins, do not use this version. Use Armory Spinnaker 2.17.8 or later.
+
+### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
+As a part of the upgrade from 2.18.x to 2.19.x, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
+
 
 ## Highlighted Updates
 
@@ -188,5 +189,3 @@ See the Open Source Spinnaker Release Notes for the versions included in this re
 * [Spinnaker's v1.19.5](https://www.spinnaker.io/community/releases/versions/1-19-5-changelog#individual-service-changes) 
 
 Armory Spinnaker 2.19.7 cherry-picks [spinnaker/fiat/pull/656](https://github.com/spinnaker/fiat/pull/656), which resolves an issue with Fiat and service accounts.
-
-

--- a/_release_notes/armoryspinnaker_v2.19.8.md
+++ b/_release_notes/armoryspinnaker_v2.19.8.md
@@ -30,10 +30,10 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 
 ## Known Issues
-There are currently no known issues with this release.
 
-### Upgrading from 2.18.x with MySQL used for Front50 will Rename Table plugin_artifacts
-As a part of upgrading from 2.18.x to 2.19.x the table **plugin_artifacts** is renamed to **plugin_info**.  Please be advised that attempting to downgrade from 2.19.x to 2.18.x will not revert naming of the table, and it will continue to be named as **plugin_info**, preventing access to the table.  
+### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
+As a part of the upgrade from 2.18.x to 2.19.x, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
+
 
 ## Highlighted Updates
 ### Armory

--- a/_release_notes/armoryspinnaker_v2.19.8.md
+++ b/_release_notes/armoryspinnaker_v2.19.8.md
@@ -32,8 +32,8 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 ## Known Issues
 There are currently no known issues with this release.
 
-
-
+### Upgrading from 2.18.x with MySQL used for Front50 will Rename Table plugin_artifacts
+As a part of upgrading from 2.18.x to 2.19.x the table **plugin_artifacts** is renamed to **plugin_info**.  Please be advised that attempting to downgrade from 2.19.x to 2.18.x will not revert naming of the table, and it will continue to be named as **plugin_info**, preventing access to the table.  
 
 ## Highlighted Updates
 ### Armory


### PR DESCRIPTION
Added to all 2.19.x release notes about Table Renaming breaking change,  where table gets renamed, does not get reverted if you need to go back to 2.18.x.  