### PR TITLE
docs(fixes): dinghy template examples and okta halyard fix

### DIFF
--- a/_spinnaker/using_dinghy.md
+++ b/_spinnaker/using_dinghy.md
@@ -871,6 +871,10 @@ In the template, the access path for that variable is: `.RawData.pusher.name`.
 
 *Note: The structure of the webhook data passed to Dinghy's template engine depends on the Git service that sends the webhook. This example uses a GitHub webhook.*
 
+## Example Templates
+
+Armory provides sample dinghy templates you can copy and extend. You can find the dinghy templates at https://github.com/armory-io/dinghy-templates
+
 
 ## Known Issue
 

--- a/_spinnaker/using_dinghy.md
+++ b/_spinnaker/using_dinghy.md
@@ -871,9 +871,10 @@ In the template, the access path for that variable is: `.RawData.pusher.name`.
 
 *Note: The structure of the webhook data passed to Dinghy's template engine depends on the Git service that sends the webhook. This example uses a GitHub webhook.*
 
+
 ## Example Templates
 
-Armory provides sample dinghy templates you can copy and extend. You can find the dinghy templates at https://github.com/armory-io/dinghy-templates
+Armory provides example dinghy templates you can copy and extend. You can find the examples in the [Armory GitHub repo](https://github.com/armory-io/dinghy-templates).
 
 
 ## Known Issue

--- a/_spinnaker_install_admin_guides/okta.md
+++ b/_spinnaker_install_admin_guides/okta.md
@@ -143,6 +143,8 @@ keytool -genkey -v -keystore $KEYSTORE_PATH -alias saml -keyalg RSA -keysize 204
         --service-address-url $SERVICE_ADDR_URL
 
     hal config security authn saml enable
+
+    hal deploy apply
     ```
 
 


### PR DESCRIPTION
Add link to dinghy example templates (doc-99), and add missing hal deploy apply to okta example (doc-103). 